### PR TITLE
handle qc for PropEr

### DIFF
--- a/src/rebar_qc.erl
+++ b/src/rebar_qc.erl
@@ -60,6 +60,7 @@ proper(Config, _AppFile) ->
 
 -define(TRIQ_MOD, triq).
 -define(EQC_MOD, eqc).
+-define(PROPER_MOD, proper).
 
 qc_opts(Config) ->
     rebar_config:get(Config, qc_opts, []).
@@ -96,7 +97,12 @@ detect_qc_mod() ->
                 {module, ?EQC_MOD} ->
                     ?EQC_MOD;
                 {error, nofile} ->
-                    ?ABORT("No QC library available~n", [])
+                    case code:ensure_loaded(?PROPER_MOD) of
+                        {module, ?PROPER_MOD} ->
+                            ?PROPER_MOD;
+                        {error, nofile} ->
+                            ?ABORT("No QC library available~n", [])
+                    end
             end
     end.
 


### PR DESCRIPTION
@tuncer even generic solution like yours:

https://github.com/tuncer/rebar/commit/2dcdc1060e005fcad4791a0da764d750fcd8a61b

is not enough because PropEr has different schema of api:

```
QC:module(M, Opts)   %% PropEr
```

instead of 

```
QC:module(Opts, M)     %% eqc
```

or 

```
QC:module(M)          %% triq
```

I still thinking that handling PropEr not violate license of PropEr it self. 

Most developers have configuration like that (in **~/.erlang**):

```
true = code:add_pathz(os:getenv("HOME")++"/.erlang.d/deps/quviq/eqc-X.Y.Z/ebin").
```

or 

```
true = code:add_pathz(os:getenv("HOME")++"/.erlang.d/deps/proper/ebin").
```

and we dont define in rebar any dependency, we just using some schema of API,
and api schema like **M:Fun(...)** can't be copyrighted it self. If we handling in same way full version of eqc which is commercially licensed why not support PropEr too (especialy when support means only call **M:F(...)**) ?

@manopapad, @kostis - could you confirm that we will not violate license of PropEr in that way? 
