### PR TITLE
Fix protobuffs if `warnings_as_errors` is enabled

### DIFF
--- a/src/rebar_protobuffs_compiler.erl
+++ b/src/rebar_protobuffs_compiler.erl
@@ -101,7 +101,8 @@ compile_each(Config, [{Proto, Beam, Hrl} | Rest]) ->
     case needs_compile(Proto, Beam) of
         true ->
             ?CONSOLE("Compiling ~s\n", [Proto]),
-            ErlOpts = rebar_utils:erl_opts(Config),
+            ErlOpts = lists:delete(warnings_as_errors,
+                                   rebar_utils:erl_opts(Config)),
             case protobuffs_compile:scan_file(Proto,
                                               [{compile_flags,ErlOpts}]) of
                 ok ->


### PR DESCRIPTION
The protobuffs compilation fails if `erl_opts` contains
`warnings_as_errors`. Filter out this flag in case the project has it
enabled.
