### PR TITLE
Allow specifying eunit suite run order in 'suites'

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -186,7 +186,7 @@ filter_suites(Config, Modules) ->
 filter_suites1(Modules, []) ->
     Modules;
 filter_suites1(Modules, Suites) ->
-    [M || M <- Modules, lists:member(M, Suites)].
+    [M || M <- Suites, lists:member(M, Modules)].
 
 %%
 %% == get matching tests ==


### PR DESCRIPTION
Normally, Rebar runs eunit tests in the order the beam files are stored in the file system (see `rebar_utils:beams`).  However, sometimes it is desirable to run the tests in a different order (e.g. to reproduce an error found on a build server).  For that case, it would make sense to use the `suites` parameter not just for selecting which modules to consider, but also for choosing the order.
