### PR TITLE
rebar_eunit:reset_after_eunit/1 mustn't remove 'included_applications'

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -629,7 +629,8 @@ reset_after_eunit({OldProcesses, WasAlive, OldAppEnvs, _OldACs}) ->
                  end,
              ok = application:unset_env(App, K)
          end || App <- Apps, App /= rebar,
-                {K, _V} <- application:get_all_env(App)],
+                {K, _V} <- application:get_all_env(App),
+                K =/= included_applications],
 
     reconstruct_app_env_vars(Apps),
 


### PR DESCRIPTION
One could argue that rebar_eunit does some pretty dangerous stuff when
trying to clean up after a test run, but specifically, it tells the
Application Controller to delete everything returned by
application:get_all_env(App). Unfortunately, included_applications
also goes, which can lead to a crash in application_controller, if
the application is subsequently unloaded.

This patch attempts the smallest possible fix: remove all env
variables except included_applications.
