### PR TITLE
Fix file handling on windows for tests

### DIFF
--- a/test/rebar_eunit_tests.erl
+++ b/test/rebar_eunit_tests.erl
@@ -337,7 +337,15 @@ basic_setup_test_() ->
          "myfunc_test() -> ?assertMatch(ok, myapp_mymod:myfunc()).\n"]).
 
 make_tmp_dir() ->
-    ok = file:make_dir(?TMP_DIR).
+    case file:make_dir(?TMP_DIR) of
+        ok ->
+            ok;
+        {error, eexist} ->
+            remove_tmp_dir(),
+            make_tmp_dir();
+        Error ->
+            throw(Error)
+    end.
 
 setup_environment() ->
     ok = make_tmp_dir(),
@@ -389,8 +397,8 @@ prepare_rebar_script() ->
         {unix, _} ->
             [] = os:cmd("chmod u+x " ++ Rebar);
         {win32, _} ->
-            {ok, _} = file:copy(?REBAR_SCRIPT ++ ".bat",
-                                ?TMP_DIR ++ "rebar.bat")
+            {ok, _} = file:copy(?REBAR_SCRIPT ++ ".cmd",
+                                ?TMP_DIR ++ "rebar.cmd")
     end.
 
 rebar() ->


### PR DESCRIPTION
Running tests on windows creates false positive due to setup failures
not executing all tests.  Checking for tmp_dir was failing on
subsequent runs.  Added cases to tmp_dir creation to delete preexisting
tmp_dirs in .eunit directory.
