### PR TITLE
Support for QuickCheck Mini

### DIFF
--- a/src/rebar_qc.erl
+++ b/src/rebar_qc.erl
@@ -175,6 +175,7 @@ qc_module(QC=triq, _QCOpts, M) ->
         Failed ->
             [Failed]
     end;
+qc_module(QC=eqc, [], M) -> QC:module(M);
 qc_module(QC=eqc, QCOpts, M) -> QC:module(QCOpts, M).
 
 find_prop_mods() ->


### PR DESCRIPTION
Hi,

QuickCheck Mini in it's latest downloadable version (1.0.1) does not provide `module/2` function, so it's imposible to use it with `rebar eqc`. This little change runs `module/1` when the list of opts is empty and makes it possible to use eqcmini with rebar.
