### PR TITLE
More error logging

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -226,6 +226,8 @@ format_warnings(Config, Source, Warnings, Opts) ->
 
 maybe_report([{error, {error, _Es, _Ws}=ErrorsAndWarnings}, {source, _}]) ->
     maybe_report(ErrorsAndWarnings);
+maybe_report([{error, E}, {source, S}]) ->
+    report(["unexpected error compiling " ++ S, io_lib:fwrite("~n~p~n", [E])]);
 maybe_report({error, Es, Ws}) ->
     report(Es),
     report(Ws);


### PR DESCRIPTION
rebar throws away some error messages, e.g. the ones generated if the yecc compiler is broken.
