### PR TITLE
Add rebar-deps env to port compiler SharedEnv

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -100,7 +100,8 @@ compile(Config, AppFile) ->
         [] ->
             ok;
         Specs ->
-            SharedEnv = rebar_config:get_env(Config, ?MODULE),
+            SharedEnv = rebar_config:get_env(Config, rebar_deps) ++
+                rebar_config:get_env(Config, ?MODULE),
 
             %% Compile each of the sources
             NewBins = compile_sources(Config, Specs, SharedEnv),


### PR DESCRIPTION
REBAR_DEPS_DIR is often needed when a nif needs to be linked with a raw
dependency.
