### PR TITLE
Fix searching for plugins

### DIFF
--- a/inttest/depplugins/depplugins_rt.erl
+++ b/inttest/depplugins/depplugins_rt.erl
@@ -1,0 +1,50 @@
+%%% @doc Plugin handling test
+%%%
+%%% This test checks if plugins are loaded correctly.
+%%%
+%%% It has three applications:
+%%% <ol>
+%%%   <li>fish. top-level module, has one dependency: `dependsonplugin'.</li>
+%%%   <li>dependsonplugin. This depends on some pre-compile actions by the
+%%%       plugin. In the test the plugin creates a file `pre.compile' in the
+%%%       top-level folder of this application.</li>
+%%%   <li>testplugin. This is a plugin application which creates the file.</li>
+%%% </ol>
+
+-module(depplugins_rt).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [
+     {copy, "../../rebar", "rebar"},
+     {copy, "rebar.config", "rebar.config"},
+     {create, "ebin/fish.app", app(fish, [])},
+
+     {create, "deps/dependsonplugin/ebin/dependsonplugin.app",
+        app(dependsonplugin, [])},
+     {copy, "rebar_dependsonplugin.config",
+        "deps/dependsonplugin/rebar.config"},
+     {copy, "testplugin_mod.erl",
+        "deps/testplugin/plugins/testplugin_mod.erl"},
+     {create, "deps/testplugin/ebin/testplugin.app",
+        app(testplugin, [])}
+    ].
+
+run(_Dir) ->
+    ?assertMatch({ok, _}, retest_sh:run("./rebar compile", [])),
+    ?assertEqual(true, filelib:is_regular("deps/dependsonplugin/pre.compile")),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/depplugins/rebar.config
+++ b/inttest/depplugins/rebar.config
@@ -1,0 +1,1 @@
+{deps, [dependsonplugin]}.

--- a/inttest/depplugins/rebar_dependsonplugin.config
+++ b/inttest/depplugins/rebar_dependsonplugin.config
@@ -1,0 +1,2 @@
+{deps, [testplugin]}.
+{plugins, [testplugin_mod]}.

--- a/inttest/depplugins/testplugin_mod.erl
+++ b/inttest/depplugins/testplugin_mod.erl
@@ -1,0 +1,6 @@
+-module(testplugin_mod).
+-compile(export_all).
+
+pre_compile(Config, _) ->
+    ok = file:write_file("pre.compile", <<"Yadda!">>),
+    rebar_log:log(info, "Wrote ~p/pre.compile~n", [rebar_utils:get_cwd()]).


### PR DESCRIPTION
If a plugin is in a dependency, rebar didn't search for it carefully
enough.

This has a pretty good impact: you no longer need to hardcore plugin directories in most cases. Avoid things like [this](https://github.com/hyperthunk/rebar_dist_plugin/blob/master/rebar.config#L13) and [this](http://lists.basho.com/pipermail/rebar_lists.basho.com/2011-March/000704.html).

In general, I think this should fix most of the plugin loading issues, especially ones that are listed in the dependencies.
