### PR TITLE
Add support for ping command on windows in the simple node runner

### DIFF
--- a/priv/templates/simplenode.reltool.config
+++ b/priv/templates/simplenode.reltool.config
@@ -20,7 +20,8 @@
        {profile, embedded},
        {incl_cond, derived},
        {excl_archive_filters, [".*"]}, %% Do not archive built libs
-       {excl_sys_filters, ["^bin/.*", "^erts.*/bin/(dialyzer|typer)",
+       {excl_sys_filters, ["^bin/(?!start_clean.boot)",
+                           "^erts.*/bin/(dialyzer|typer)",
                            "^erts.*/(doc|info|include|lib|man|src)"]},
        {excl_app_filters, ["\.gitignore"]},
        {app, {{nodeid}}, [{mod_cond, app}, {incl_cond, include}]}
@@ -32,6 +33,8 @@
            {mkdir, "log/sasl"},
            {copy, "files/erl", "\{\{erts_vsn\}\}/bin/erl"},
            {copy, "files/nodetool", "\{\{erts_vsn\}\}/bin/nodetool"},
+           {copy, "{{nodeid}}/bin/start_clean.boot",
+                  "\{\{erts_vsn\}\}/bin/start_clean.boot"},
            {copy, "files/{{nodeid}}", "bin/{{nodeid}}"},
            {copy, "files/{{nodeid}}.cmd", "bin/{{nodeid}}.cmd"},
            {copy, "files/start_erl.cmd", "bin/start_erl.cmd"},

--- a/priv/templates/simplenode.windows.runner.cmd
+++ b/priv/templates/simplenode.windows.runner.cmd
@@ -30,6 +30,7 @@
 @set epmd="%erts_bin%\epmd.exe"
 @set escript="%erts_bin%\escript.exe"
 @set werl="%erts_bin%\werl.exe"
+@set nodetool="%erts_bin%\nodetool"
 
 @if "%1"=="usage" @goto usage
 @if "%1"=="install" @goto install
@@ -38,13 +39,14 @@
 @if "%1"=="stop" @goto stop
 @if "%1"=="restart" @call :stop && @goto start
 @if "%1"=="console" @goto console
+@if "%1"=="ping" @goto ping
 @if "%1"=="query" @goto query
 @if "%1"=="attach" @goto attach
 @if "%1"=="upgrade" @goto upgrade
 @echo Unknown command: "%1"
 
 :usage
-@echo Usage: %~n0 [install^|uninstall^|start^|stop^|restart^|console^|query^|attach^|upgrade]
+@echo Usage: %~n0 [install^|uninstall^|start^|stop^|restart^|console^|ping^|query^|attach^|upgrade]
 @goto :EOF
 
 :install
@@ -69,6 +71,11 @@
 
 :console
 @start "%node_name% console" %werl% -boot "%node_boot_script%" -config "%sys_config%" -args_file "%vm_args%" -sname %node_name%
+@goto :EOF
+
+:ping
+@%escript% %nodetool% ping -sname "%node_name%" -setcookie "%erlang_cookie%"
+@exit %ERRORLEVEL%
 @goto :EOF
 
 :query


### PR DESCRIPTION
Hi Dave,

This PR adds the support for the ping command in the simple node runner for Windows.
This way it is possible to do `mynode ping` on Linux and `mynode.cmd ping` on Windows.

If I spotted the issue correctly, the packaged `escript` cannot be executed on Windows and the consequence is that `nodetool` cannot be used right out of the box.
I fixed this issue either by:
-  copying `erl.ini` from my Erlang installation folder, this option is not viable since I relies on an installed Erlang on the system.
- or copying `start_clean.boot` in packaged erts bin directory, this is the option I implemented in this PR.

So what this PR actually does is to:
-  add the ping command to `simplenode.windows.runner.cmd`
- exclude all but 'start_clean.boot` in 'simplenode.reltool.config'
- use overlay to copy 'start_clean.boot` erts bin directory.

Tested with R16B only...

Cheers,
syl20bnr
