### PR TITLE
Use "pwd -P" to get the current physical path.

### DIFF
--- a/priv/templates/simplenode.erl.script
+++ b/priv/templates/simplenode.erl.script
@@ -20,7 +20,7 @@ unset POSIX_SHELL
 ## start_clean.boot file available in $ROOTDIR/release/VSN.
 
 # Determine the abspath of where this script is executing from.
-ERTS_BIN_DIR=$(cd ${0%/*} && pwd)
+ERTS_BIN_DIR=$(cd ${0%/*} && pwd -P)
 
 # Now determine the root directory -- this script runs from erts-VSN/bin,
 # so we simply need to strip off two dirs from the end of the ERTS_BIN_DIR

--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -15,7 +15,7 @@ fi
 # clear it so if we invoke other scripts, they run as ksh
 unset POSIX_SHELL
 
-RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
+RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd -P)
 
 CALLER_DIR=$PWD
 

--- a/test/upgrade_project/rel/files/dummy
+++ b/test/upgrade_project/rel/files/dummy
@@ -2,7 +2,7 @@
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 
-RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
+RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd -P)
 
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
 RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc

--- a/test/upgrade_project/rel/files/erl
+++ b/test/upgrade_project/rel/files/erl
@@ -10,7 +10,7 @@
 ## file available in $ROOTDIR/release/VSN.
 
 # Determine the abspath of where this script is executing from.
-ERTS_BIN_DIR=$(cd ${0%/*} && pwd)
+ERTS_BIN_DIR=$(cd ${0%/*} && pwd -P)
 
 # Now determine the root directory -- this script runs from erts-VSN/bin,
 # so we simply need to strip off two dirs from the end of the ERTS_BIN_DIR


### PR DESCRIPTION
It is a portable version of the realpath(1) utility that you can find on Mac OS X and FreeBSD (see also The Open Group Base Specifications Issue 6, IEEE Std 1003.1). It will not work if the pwd(1) command is not Posix compliant, which should be quite rare today.

Without the -P flag, pwd(1) might return different values when the current path contains one or more symlinks, depending on how you got into the current directory.

For instance:

$ pwd
/home/olgeni
$ pwd -P
/usr/home/olgeni

In simplenode.runner, this may cause PIPE_DIR to have different values on each use, which will make it impossible to connect to the running node unless you guess the correct path yourself.
