### PR TITLE
External deps_dir should have higher priority than the config one

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -241,10 +241,11 @@ info_help(Description) ->
 
 %% Added because of trans deps,
 %% need all deps in same dir and should be the one set by the root rebar.config
+%% In case one is given globally, it has higher priority
 %% Sets a default if root config has no deps_dir set
 set_shared_deps_dir(Config, []) ->
-    GlobalDepsDir = rebar_config:get_global(Config, deps_dir, "deps"),
-    DepsDir = rebar_config:get_local(Config, deps_dir, GlobalDepsDir),
+    LocalDepsDir = rebar_config:get_local(Config, deps_dir, "deps"),
+    DepsDir = rebar_config:get_global(Config, deps_dir, LocalDepsDir),
     rebar_config:set_xconf(Config, deps_dir, DepsDir);
 set_shared_deps_dir(Config, _DepsDir) ->
     Config.


### PR DESCRIPTION
The external deps_dir should have higher priority because
it is used by scripts and other build tools to set up the
location of the dependencies. This commit ensures that,
even if a project has set deps_dir in its config file has
lower preference than the command line one.
