### PR TITLE
Allow the use of absolute paths in the lib_dirs configuration setting

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -414,7 +414,7 @@ expand_lib_dirs([Dir | Rest], Root, Acc) ->
     Apps = filelib:wildcard(filename:join([Dir, "*", "ebin"])),
     FqApps = case filename:pathtype(Dir) of
                  absolute -> Apps;
-                 relative -> [filename:join([Root, A]) || A <- Apps]
+                 _        -> [filename:join([Root, A]) || A <- Apps]
              end,
     expand_lib_dirs(Rest, Root, Acc ++ FqApps).
 


### PR DESCRIPTION
Right now the `{lib_dirs, []}` configuration setting in `rebar.config` only accepts relative paths. This commit also adds support for absolute paths.
