### PR TITLE
Incorrect REMSH args when sname is used.

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -136,7 +136,7 @@ ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
 NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME_ARG $COOKIE_ARG"
 
 # Setup remote shell command to control node
-REMSH="$ERTS_PATH/erl $REMSH_NAME_ARG $REMSH_REMSH_ARG $COOKIE_ARG"
+REMSH="$ERTS_PATH/erl -hidden $REMSH_NAME_ARG $REMSH_REMSH_ARG $COOKIE_ARG"
 
 # Common functions
 


### PR DESCRIPTION
When a node is configured with -sname in app.config or sys.config
the REMSH_NAME_ARG and REMSH_REMSH_ARG arguments are incorrect.
