### PR TITLE
mib_to_hrl compilation verbosity via 'mib_opts'

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -34,6 +34,7 @@
          info/2]).
 
 -include("rebar.hrl").
+-include_lib("stdlib/include/erl_compile.hrl").
 
 %% ===================================================================
 %% Public API
@@ -401,7 +402,14 @@ compile_mib(Source, Target, Config) ->
     case snmpc:compile(Source, Opts) of
         {ok, _} ->
             Mib = filename:rootname(Target),
-            ok = snmpc:mib_to_hrl(Mib),
+            MibToHrlOpts =
+                case proplists:get_value(verbosity, Opts, undefined) of
+                    undefined ->
+                        #options{specific = []};
+                    Verbosity ->
+                        #options{specific = [{verbosity, Verbosity}]}
+                end,
+            ok = snmpc:mib_to_hrl(Mib, Mib, MibToHrlOpts),
             Hrl_filename = Mib ++ ".hrl",
             rebar_file_utils:mv(Hrl_filename, "include"),
             ok;


### PR DESCRIPTION
Previously, the configuration setting 'mib_opts' in rebar.config
would affect the call to snmpc:compile/2, so that (for example)
verbosity could be controlled.  However, the subsequent call to
snmpc:mib_to_hrl/1 did not include any of these options, so it
did not appear to be possible to control the verbosity of the
process of converting a MIB to a .hrl file.  To make matters
worse, the default was to dump a full trace -- including debug
output and various logging -- so the act of compiling a large
number of MIBs could result in a huge amount of "noisy" output
that hid any signal (meaningful warnings, errors, etc.).

This commit addresses that issue by replacing the call to
snmpc:mib_to_hrl/1 with a call to snmpc:mib_to_hrl/3 instead,
which includes an "options" argument that, at present, is only
capable of setting verbosity.  The verbosity setting is taken
from the 'mib_opts' setting in rebar_config, if present, and
the approriate kind of argument is passed to snmpc:mib_to_hrl/3.

It should be noted that snmpc:mib_to_hrl/3 is not listed in
Erlang's documentation, but does appear in the list of "API"
exports at the top of snmpc.erl in R15B01 (and remains that way
in R16B01), so this appears to be more of a documentation oversight
than the use of a deep, dark function call that was not intended
to be public.  snmpc:mib_to_hrl/3 accepts an #options{} record
(defined in lib/srdlib/include/erl_compile.hrl within Erlang's
source distribution), though most of the fields in that record
are ignored by snmpc:mib_to_hrl/3; only verbosity can be controlled
this way.
