### PR TITLE
Add support for the Perforce VCS client via the "git p4" command

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -157,6 +157,8 @@
         {application_name, "1.0.*"},
         {application_name, "1.0.*",
          {git, "git://github.com/rebar/rebar.git", {branch, "master"}}},
+        {application_name, ".*",
+         {git_p4, "//depot/path/to/source"}},
         %% Dependencies can be marked as 'raw'. Rebar does not require
         %% such dependencies to have a standard Erlang/OTP layout
         %% which assumes the presence of either


### PR DESCRIPTION
As an alternative to pull request https://github.com/rebar/rebar/pull/136 (Perforce support via the official "p4" command), this uses the Git subcommand `git p4` (http://git-scm.com/docs/git-p4).

The disadvantage of this method of pulling in Perforce-managed dependencies is that `git p4` is not present in all Git installations and it adds an extra layer of indirection to things.  On the other hand, the messiness of using Perforce for dependencies get hidden behind some code maintained by Someone Else, rather than teaching Rebar to understand a new VCS.
