### PR TITLE
Change rebar_ct:check_log/3 to use double quotes

### DIFF
--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -149,7 +149,7 @@ check_fail_log(Config, RawLog, Command, Result) ->
 
 check_log(Config,RawLog,Fun) ->
     {ok, Msg} =
-        rebar_utils:sh("grep -e 'TEST COMPLETE' -e '{error,make_failed}' "
+        rebar_utils:sh("grep -e \"TEST COMPLETE\" -e \"{error,make_failed}\" "
                        ++ RawLog, [{use_stdout, false}]),
     MakeFailed = string:str(Msg, "{error,make_failed}") =/= 0,
     RunFailed = string:str(Msg, ", 0 failed") =:= 0,


### PR DESCRIPTION
The call to the grep program in rebar_ct:check_log/3 used single
quotation marks around the strings grep should search for. This works
well in most cases but fails on Windows 7 using GNU grep 2.5.4 as
installed by the Chocolatey package GnuWin 0.6.3.1 with the follow
message:

ERROR: cmd /q /c grep -e 'TEST COMPLETE' -e '{error,make_failed}'
ct/raw.log
failed with error: 2 and output:
grep: COMPLETE': No such file or directory

This commit changes the single quotation marks to double quotation
marks. I've tested this using GNU grep 2.5.3 on a Debian Linux machine
and it works well.
