### PR TITLE
Add config support for protobuffs

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -86,6 +86,12 @@
 %% Options for the ErlyDTL compiler
 {erlydtl_opts, []}.
 
+%% == Protobuffs Compiler ==
+
+%% Options for protobuffs compiler. If "compile_flags" is not set,
+%% it will use erl_opts as "compile_flags"
+{protobuffs_opts, []}.
+
 %% == EUnit ==
 
 %% Options for eunit:test()


### PR DESCRIPTION
The current protobuffs config only copy "erl_opts" to
"compile_flags". Some other configs such as "imports_dir" is very
importent, too.
