### PR TITLE
Fix update-deps with certain forms of the {tag, ...} type

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -564,7 +564,7 @@ update_source1(AppDir, {git, _Url, {branch, Branch}}) ->
     rebar_utils:sh(?FMT("git pull --ff-only --no-rebase -q origin ~s", [Branch]), ShOpts);
 update_source1(AppDir, {git, _Url, {tag, Tag}}) ->
     ShOpts = [{cd, AppDir}],
-    rebar_utils:sh("git fetch --tags origin", ShOpts),
+    rebar_utils:sh("git fetch origin", ShOpts),
     rebar_utils:sh(?FMT("git checkout -q ~s", [Tag]), ShOpts);
 update_source1(AppDir, {git, _Url, Refspec}) ->
     ShOpts = [{cd, AppDir}],


### PR DESCRIPTION
Sometimes tags like 1.1-3-g3af5478 or d20b53f0 are encountered. The
first is the output of 'git describe', and the second is just a regular
git SHA. git fetch --tags will not pull these down, so do both a git
fetch and a git fetch --tags to get both SHAs and tags.

This is a little hard to test if you don't have a stale dep hanging around somewhere, because I don't know of a way to make a git checkout 'forget' SHAs once it has seen them, but I had a stale riak tree hanging around and was able to check this worked.
