### PR TITLE
Feature: force protocol when getting dependencies

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -488,7 +488,7 @@ use_source(Config, Dep, Count) ->
 
 set_protocol(bzr, "ssh", Url) -> 
     re:replace(Url, "^.[^:]*","bzr+ssh",[{return,list}]);
-set_protocol(fossil, _, Url) -> 
+set_protocol(fossil, _Protocol, Url) -> 
     Url;
 set_protocol(git, Protocol, Url) -> 
     re:replace(re:replace(Url, "^.[^:]*",Protocol,[{return,list}]), ".git$", "",[{return,list}]);


### PR DESCRIPTION
Added because of not always being able to use certain protocols (mainly git) from corporate intranet. And dirtying dependencies by editing their configuration files is well, dirty.

To force ssh, http or https use force_protocol=Protocol.

In effect

```
                    rebar get-deps force_protocol=https
```
