### PR TITLE
Add Core Erlang support.

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -377,7 +377,7 @@ internal_core_compile(Config, Source, Outdir, ErlOpts) ->
     {Module, Hrls} = inspect(Source, include_path(Source, Config)),
 
     %% Construct the target filename
-    Target = filename:join([Outdir | string:tokens(Module, ".")]) ++ ".beam",
+    Target = filename:join([Outdir,Module]) ++ ".beam",
     ok = filelib:ensure_dir(Target),
 
     %% If the file needs compilation, based on last mod date of includes or


### PR DESCRIPTION
Support the compilation of .core files in the directory for applications
which use source code authored directly in Core Erlang.

Conflicts:
    src/rebar_erlc_compiler.erl

Ported from basho/rebar#384.
