### PR TITLE
Init RUNNER_SCRIPT var in simplenode.runner

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -16,6 +16,7 @@ fi
 unset POSIX_SHELL
 
 RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd -P)
+RUNNER_SCRIPT=${0##*/}
 
 CALLER_DIR=$PWD
 


### PR DESCRIPTION
RUNNER_SCRIPT variable is not initialized in simplenode.runner and it's
referenced when calling sudo.
