### PR TITLE
generate-upgrade can now take target_dir argument

### DIFF
--- a/src/rebar_upgrade.erl
+++ b/src/rebar_upgrade.erl
@@ -87,7 +87,8 @@ info(help, 'generate-upgrade') ->
     ?CONSOLE("Build an upgrade package.~n"
              "~n"
              "Valid command line options:~n"
-             "  previous_release=path~n",
+             "  previous_release=path~n"
+             "  target_dir=target_dir (optional)~n",
              []).
 
 run_checks(Config, OldVerPath, ReltoolConfig) ->
@@ -97,10 +98,7 @@ run_checks(Config, OldVerPath, ReltoolConfig) ->
 
     {Name, Ver} = rebar_rel_utils:get_reltool_release_info(ReltoolConfig),
 
-    NewVerPath =
-        filename:join(
-          [rebar_rel_utils:get_target_parent_dir(Config, ReltoolConfig),
-           Name]),
+    NewVerPath = rebar_rel_utils:get_target_dir(Config, ReltoolConfig),
     true = rebar_utils:prop_check(filelib:is_dir(NewVerPath),
                                   "Release directory doesn't exist (~p)~n",
                                   [NewVerPath]),


### PR DESCRIPTION
Previous generate-upgrade required renames in rel/ directory:

```
rebar generate
...changing code...
mv rel/<release> rel/<release_prev>
rebar generate
rebar generate-upgrade previous_release=<release_prev>
```

With the proposed changes you can now do the same without moving things:

```
rebar generate # default target dir: rel/<release>
...changing code...
rebar generate target_dir=<release_new>
rebar generate-upgrade target_dir=<release_new> previous_release=<release>
```
