### PR TITLE
Xref extra path

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -221,6 +221,11 @@
 
 {xref_warnings, false}.
 
+%% optional extra paths to include in xref:set_library_path/2.
+%% specified relative location of rebar.config.
+%% e.g. {xref_extra_paths,["../gtknode/src"]}
+{xref_extra_paths,[]}.
+
 %% xref checks to run
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, exports_not_used,

--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -103,9 +103,11 @@ info(help, xref) ->
        "Valid rebar.config options:~n"
        "  ~p~n"
        "  ~p~n"
+       "  ~p~n"
        "  ~p~n",
        [
         {xref_warnings, false},
+        {xref_extra_paths,[]},
         {xref_checks, [undefined_function_calls, undefined_functions,
                        locals_not_used, exports_not_used,
                        deprecated_function_calls, deprecated_functions]},
@@ -146,6 +148,7 @@ code_path(Config) ->
     %% properly into the overall compile code path if possible.
     BaseDir = rebar_config:get_xconf(Config, base_dir),
     [P || P <- code:get_path() ++
+              rebar_config:get(Config, xref_extra_paths, []) ++
               [filename:join(BaseDir, filename:join(SubDir, "ebin"))
                || SubDir <- rebar_config:get(Config, sub_dirs, [])],
           filelib:is_dir(P)].


### PR DESCRIPTION
introduce the config "xref_extra_paths".
xref_extra_paths is a (possibly empty) list of paths, which are added to the xref library path (using xref:set_library_path/2). Non-existing paths are filtered out.
This feature adds some flexibility in specifying code that is called by my application, but is not a rebar dependency.
