### PR TITLE
Adapt erlydtl compiler plugin to latest version of erlydtl

### DIFF
--- a/src/rebar_erlydtl_compiler.erl
+++ b/src/rebar_erlydtl_compiler.erl
@@ -217,6 +217,8 @@ do_compile(Config, Source, Target, DtlOpts) ->
                          Opts) of
         ok ->
             ok;
+        {ok, _Mod} ->
+            ok;
         {ok, _Mod, Ws} ->
             rebar_base_compiler:ok_tuple(Config, Source, Ws);
         {ok, _Mod, _Bin, Ws} ->


### PR DESCRIPTION
Latest as of the time of this pull request was 0.8.1 (a 0.8.2 has recently been released which fixes the  `compile_dir` function; which rebar doesn't use however).
