### PR TITLE
Add random_suite_order option to eunit command

### DIFF
--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -369,6 +369,8 @@ eunit       [suite[s]=foo]               Run eunit tests in foo.erl and
                                          no such test exists, run the test whose
                                          name starts with bar in the suite's
                                          _tests module
+            [random_suite_order=true]    Run tests in a random order, either with
+            [random_suite_order=Seed]    a random seed for the PRNG, or a specific one.
 
 ct          [suite[s]=] [case=]          Run common_test suites
 

--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -126,6 +126,9 @@ info_help(Description) ->
        "               name starts with bar and, if no such test exists,~n"
        "               run the test whose name starts with bar in the~n"
        "               suite's _tests module)~n"
+       "  random_suite_order=true (Run tests in random order)~n"
+       "  random_suite_order=Seed (Run tests in random order,~n"
+       "                           with the PRNG seeded with Seed)~n"
        "  compile_only=true (Compile but do not run tests)",
        [
         Description,


### PR DESCRIPTION
Option takes either 'true' or a numeric seed value. If true is passed, a
random seed is generated and used. The numeric seed value is printed for
repeatability.

The idea here is to root out test suites that are order dependant, or
that fail in the presence of certain orderings.

cc @jaredmorrow
