### PR TITLE
Add REBAR to environment before executing hooks

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -496,8 +496,9 @@ run_modules([Module | Rest], Command, Config, File) ->
             {Module, Error}
     end.
 
-apply_hooks(Mode, Config, Command, Env) ->
+apply_hooks(Mode, Config, Command, Env0) ->
     Hooks = rebar_config:get_local(Config, Mode, []),
+    Env = rebar_utils:patch_env(Config, Env0),
     lists:foreach(fun apply_hook/1,
                   [{Env, Hook} || Hook <- Hooks,
                                   element(1, Hook) =:= Command orelse

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -53,7 +53,8 @@
          src_dirs/1,
          ebin_dir/0,
          base_dir/1,
-         processing_base_dir/1, processing_base_dir/2]).
+         processing_base_dir/1, processing_base_dir/2,
+         patch_env/2]).
 
 -include("rebar.hrl").
 
@@ -318,6 +319,23 @@ processing_base_dir(Config) ->
 processing_base_dir(Config, Dir) ->
     AbsDir = filename:absname(Dir),
     AbsDir =:= base_dir(Config).
+
+%% @doc Returns the list of environment variables including 'REBAR' which points to the
+%% rebar executable used to execute the currently running command. The environment is
+%% not modified if rebar was invoked programmatically.
+-spec patch_env(rebar_config:config(), [{string(), string()}]) -> [{string(), string()}].
+patch_env(Config, []) ->
+    % if we reached an empty list the env did not contain the REBAR variable
+    case rebar_config:get_xconf(Config, escript, "") of
+        "" -> % rebar was invoked programmatically
+            [];
+        Path ->
+            [{"REBAR", Path}]
+    end;
+patch_env(_Config, [{"REBAR", _} | _]=All) ->
+    All;
+patch_env(Config, [E | Rest]) ->
+    [E | patch_env(Config, Rest)].
 
 %% ====================================================================
 %% Internal functions


### PR DESCRIPTION
REBAR will be set to the rebar binary which was executed and runs the
builds. Enables the use of the same binary for rebar invocations as
part of a pre or post hook like so:

```
${REBAR} escriptize
```
