### PR TITLE
Add partial support for Erlang/OTP 17

### DIFF
--- a/src/rebar_require_vsn.erl
+++ b/src/rebar_require_vsn.erl
@@ -34,7 +34,8 @@
          eunit/2]).
 
 %% for internal use only
--export([info/2]).
+-export([info/2,
+         version_tuple/2]).
 
 %% ===================================================================
 %% Public API
@@ -110,7 +111,7 @@ check_versions(Config) ->
     end.
 
 version_tuple(OtpRelease, Type) ->
-    case re:run(OtpRelease, "R(\\d+)B?-?(\\d+)?", [{capture, all, list}]) of
+    case re:run(OtpRelease, "R?(\\d+)B?-?(\\d+)?", [{capture, all, list}]) of
         {match, [_Full, Maj, Min]} ->
             {list_to_integer(Maj), list_to_integer(Min)};
         {match, [_Full, Maj]} ->

--- a/test/rebar_require_vsn_tests.erl
+++ b/test/rebar_require_vsn_tests.erl
@@ -1,0 +1,23 @@
+-module(rebar_require_vsn_tests).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+version_tuple_test_() ->
+    [%% typical cases
+     ?_assert(rebar_require_vsn:version_tuple("R15B", "eunit") =:= {15, 0}),
+     ?_assert(rebar_require_vsn:version_tuple("R15B01", "eunit") =:= {15, 1}),
+     ?_assert(rebar_require_vsn:version_tuple("R15B02", "eunit") =:= {15, 2}),
+     ?_assert(rebar_require_vsn:version_tuple("R15B03-1", "eunit") =:= {15, 3}),
+     ?_assert(rebar_require_vsn:version_tuple("R15B03", "eunit") =:= {15, 3}),
+     ?_assert(rebar_require_vsn:version_tuple("R16B", "eunit") =:= {16, 0}),
+     ?_assert(rebar_require_vsn:version_tuple("R16B01", "eunit") =:= {16, 1}),
+     ?_assert(rebar_require_vsn:version_tuple("R16B02", "eunit") =:= {16, 2}),
+     ?_assert(rebar_require_vsn:version_tuple("R16B03", "eunit") =:= {16, 3}),
+     ?_assert(rebar_require_vsn:version_tuple("R16B03-1", "eunit") =:= {16, 3}),
+     ?_assert(rebar_require_vsn:version_tuple("17", "eunit") =:= {17, 0}),
+     %% error cases
+     ?_assertException(throw, rebar_abort, rebar_require_vsn:version_tuple("", "eunit")),
+     ?_assertException(throw, rebar_abort, rebar_require_vsn:version_tuple("abc", "eunit"))
+    ].


### PR DESCRIPTION
Allow rebar to compile applications using Erlang/OTP 17 and older
versions.  This patch only provides partial support since the rebar
tool itself must be compiled using an Erlang/OTP version that is older
than 17.
