### PR TITLE
fixed specs for some functions which are deprecated in otp17

### DIFF
--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -41,11 +41,11 @@
 
 -record(config, { dir :: file:filename(),
                   opts = [] :: list(),
-                  globals = new_globals() :: dict(),
-                  envs = new_env() :: dict(),
+                  globals = new_globals() :: dict:dict(),
+                  envs = new_env() :: dict:dict(),
                   %% cross-directory/-command config
-                  skip_dirs = new_skip_dirs() :: dict(),
-                  xconf = new_xconf() :: dict() }).
+                  skip_dirs = new_skip_dirs() :: dict:dict(),
+                  xconf = new_xconf() :: dict:dict() }).
 
 -export_type([config/0]).
 

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -521,19 +521,19 @@ expand_file_names(Files, Dirs) ->
               end
       end, Files).
 
--spec get_parents(digraph(), file:filename()) -> [file:filename()].
+-spec get_parents(digraph:graph(), file:filename()) -> [file:filename()].
 get_parents(G, Source) ->
     %% Return all files which the Source depends upon.
     digraph_utils:reachable_neighbours([Source], G).
 
--spec get_children(digraph(), file:filename()) -> [file:filename()].
+-spec get_children(digraph:graph(), file:filename()) -> [file:filename()].
 get_children(G, Source) ->
     %% Return all files dependent on the Source.
     digraph_utils:reaching_neighbours([Source], G).
 
 -spec internal_erl_compile(rebar_config:config(), file:filename(),
                            file:filename(), list(),
-                           digraph()) -> 'ok' | 'skipped'.
+                           digraph:graph()) -> 'ok' | 'skipped'.
 internal_erl_compile(Config, Source, OutDir, ErlOpts, G) ->
     %% Determine the target name and includes list by inspecting the source file
     Module = filename:basename(Source, ".erl"),


### PR DESCRIPTION
dict() and digraph() are deprecated in OTP17 and will be removed in OTP18
