### PR TITLE
Use target_dir as source of new version in generate-appups

### DIFF
--- a/src/rebar_appups.erl
+++ b/src/rebar_appups.erl
@@ -54,7 +54,7 @@
 
     %% Get the new and old release name and versions
     {Name, _Ver} = rebar_rel_utils:get_reltool_release_info(ReltoolConfig),
-    NewVerPath = filename:join([TargetParentDir, Name]),
+    NewVerPath = rebar_rel_utils:get_target_dir(Config, ReltoolConfig),
     {NewName, NewVer} = rebar_rel_utils:get_rel_release_info(Name, NewVerPath),
     {OldName, OldVer} = rebar_rel_utils:get_rel_release_info(Name, OldVerPath),
 


### PR DESCRIPTION
Not sure what exact reason of setting NewVerPath as rel + `first rel name from reltool.config` so trying to make this command more correct.