### PR TITLE
Use lowercase for Windows drive name to resolve issue #250

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -316,8 +316,8 @@ processing_base_dir(Config) ->
     processing_base_dir(Config, Cwd).
 
 processing_base_dir(Config, Dir) ->
-    Dir_abs = filename:absname(Dir),
-    Dir_abs =:= filename:absname(base_dir(Config)).
+    AbsDir = filename:absname(Dir),
+    AbsDir =:= base_dir(Config).
 
 %% ====================================================================
 %% Internal functions


### PR DESCRIPTION
On windows, bootstrap.bat failed with next error.
Command 'escriptize' not understood or not applicable

This happens because the drive name in path got from rebar_utils:get_cwd() and base_dir(Config) are different case.
Made the drive name the same lowercase using filename:absname().
