### PR TITLE
Using the test config to generate the erl_opts when compiling for tests

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -172,8 +172,8 @@ test_compile(Config, Cmd, OutDir) ->
     %% Compile erlang code to OutDir, using a tweaked config
     %% with appropriate defines for eunit, and include all the test modules
     %% as well.
-    ok = doterl_compile(test_compile_config(Config, ErlOpts, Cmd),
-                        OutDir, TestErls, ErlOpts),
+    TestConfig = test_compile_config(Config, ErlOpts, Cmd),
+    ok = doterl_compile(TestConfig, OutDir, TestErls, ebar_utils:erl_opts(TestConfig)),
 
     {ok, SrcErls}.
 

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -173,7 +173,7 @@ test_compile(Config, Cmd, OutDir) ->
     %% with appropriate defines for eunit, and include all the test modules
     %% as well.
     TestConfig = test_compile_config(Config, ErlOpts, Cmd),
-    ok = doterl_compile(TestConfig, OutDir, TestErls, ebar_utils:erl_opts(TestConfig)),
+    ok = doterl_compile(TestConfig, OutDir, TestErls, rebar_utils:erl_opts(TestConfig)),
 
     {ok, SrcErls}.
 


### PR DESCRIPTION
https://github.com/rebar/rebar/commit/03fe5318c6cdc0a9eb1c0a9ee9d9267791ca4dda seems to have broken tests for me: the `TEST` macro isn't defined when compiling for tests any more.

You can see that when running `rebar enuit | grep erl_opts -A 5` which will output the compiling options when running tests (see https://github.com/rebar/rebar/blob/837df640872d6a5d5d75a7308126e2769d7babad/src/rebar_erlc_compiler.erl#L280).

On version 2.2.0 (or if you just revert https://github.com/rebar/rebar/commit/03fe5318c6cdc0a9eb1c0a9ee9d9267791ca4dda), you will get something like:

```
root@delivery-ubuntu-1204:/mnt/sync/delivery# rebar eunit -vvv | grep erl_opts -A 5
DEBUG: erl_opts [debug_info,
                 {d,'TEST'},
                 debug_info,debug_info,warnings_as_errors,
                 {d,'USE_JSX'}]
```

With the current code, you'll get something along the lines of

```
root@delivery-ubuntu-1204:/mnt/sync/delivery# rebar eunit -vvv | grep erl_opts -A 5
DEBUG: erl_opts [debug_info,debug_info,warnings_as_errors,{d,'USE_JSX'}]
```

Notice that in particular `{d,'TEST'}` isn't there any more.

Additionally, I have checked that I have not re-introduced the bug from https://github.com/rebar/rebar/issues/220.
