### PR TITLE
improve output when using `rebar shell`

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -123,3 +123,4 @@ Dave Thomas
 Evgeniy Khramtsov
 YeJun Su
 Yuki Ito
+alisdair sullivan

--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -409,6 +409,9 @@ qc                                       Test QuickCheck properties
 
 xref                                     Run cross reference analysis
 
+shell                                    Start a shell similar to
+                                         'erl -pa ebin -pa deps/*/ebin'
+
 help                                     Show the program options
 version                                  Show version information
 ">>,


### PR DESCRIPTION
before:

``` erlang
vagrant@precise32:~/dev/erlang/rebar$ ./rebar shell
==> rebar (shell)
NOTICE: Using experimental 'shell' command
Erlang/OTP 17 [erts-6.0] [source-07b8f44] [async-threads:10] [hipe] [kernel-poll:false]


=ERROR REPORT==== 20-May-2014::06:50:40 ===
                                           driver_select(0xb6fc0a60, 0, ERL_DRV_READ ERL_DRV_USE, 1) by tty_sl (tty_sl -c -e) driver #Port<0.3993> stealing control of fd=0 from input driver fd (0/1) #Port<0.493> 

                                                    Eshell V6.0  (abort with ^G)
                                                                               1> Eshell V6.0  (abort with ^G)
1> rebar:version().
rebar 2.3.0 17 20140520_065034 git 2.3.0-13-g93621d0
ok
```

after:

``` erlang
$ ./rebar shell
==> rebar (shell)
NOTICE: Using experimental 'shell' command
Erlang/OTP 17 [erts-6.0] [source-07b8f44] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V6.0  (abort with ^G)
1> rebar:version().
rebar 2.3.0 17 20140520_063343 git 2.3.0-13-g93621d0-dirty
ok 
```
