### PR TITLE
Error 'Command not found' when sname is used

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -100,7 +100,7 @@ case "$REMSH_NAME" in
     *)
         REMSH_NAME_PART="$REMSH_NAME"
         if [ "$REMSH_TYPE" = "-sname" ]; then
-            REMSH_HOSTNAME_PART= "$HOSTNAME"
+            REMSH_HOSTNAME_PART="$HOSTNAME"
         else
             # -name type, check if `hostname` is fqdn
             if [ "$MAYBE_FQDN_HOSTNAME" = "$HOSTNAME" ]; then


### PR DESCRIPTION
When a node is configured with -sname the REMSH_NAME_PART argument should be defined with using command 'hostname' but error occurs due extra space
