### PR TITLE
Fix upgrade error

### DIFF
--- a/src/rebar_rel_utils.erl
+++ b/src/rebar_rel_utils.erl
@@ -35,6 +35,7 @@
          get_rel_apps/2,
          get_previous_release_path/1,
          get_rel_file_path/2,
+         get_rel_file_path/3,
          load_config/2,
          get_sys_tuple/1,
          get_excl_lib_tuple/1,
@@ -106,9 +107,18 @@ get_rel_apps(Name, Path) ->
 
 %% Get rel file path from name and path
 get_rel_file_path(Name, Path) ->
-    [RelFile] = filelib:wildcard(filename:join([Path, "releases", "*",
-                                                Name ++ ".rel"])),
-    RelFile.
+    PVer = get_permanent_version(Path),
+    get_rel_file_path(Name, Path, PVer).
+
+get_rel_file_path(Name, Path, Version) ->
+    Dir   = filename:join([Path, "releases", Version]),
+    Path1 = filename:join([Dir, Name ++ "_" ++ Version ++".rel"]),
+    Path2 = filename:join([Dir, Name ++ ".rel"]),
+    case {filelib:is_file(Path1), filelib:is_file(Path2)} of
+        {true, _} -> Path1;
+        {_, true} -> Path2;
+        _ -> ?ABORT("can not find .rel file for version ~p", [Version])
+    end.
 
 %% Get the previous release path from a global variable
 get_previous_release_path(Config) ->
@@ -244,3 +254,16 @@ expand_rel_version(Config, {rel, Name, Version, Apps}, Dir) ->
     {NewConfig, {rel, Name, VsnString, Apps}};
 expand_rel_version(Config, Other, _Dir) ->
     {Config, Other}.
+
+%% get permanent version from start_erl.data
+get_permanent_version(Path) ->
+    DataFile = filename:join([Path, "releases", "start_erl.data"]),
+    case file:read_file(DataFile) of
+        {ok, DataBin} ->
+            [_, Version] = string:tokens(
+                             string:strip(binary_to_list(DataBin), right, $\n),
+                             " "),
+            Version;
+        {error, enoent} ->
+            ?ABORT("start_erl.data is missing", [])
+    end.

--- a/test/upgrade_project/README.md
+++ b/test/upgrade_project/README.md
@@ -38,3 +38,8 @@
 
     erl> release_handler:which_releases().
     erl> dummy_server:get_state().
+
+#### Building version 0.3
+    rm -r rel/dummy
+
+    # Now repeat steps in 'Building version 0.2' and 'Deploying with release_handler'


### PR DESCRIPTION
When following instructions in `test/upgrade_project/README.md,` I failed during releasing another dummy_0.3 with an error message — `{error, {no_matching_relup, "0.3", "0.2"}}`, supposing 0.2 is the base version. Because, at this moment, rebar uses wildcard to extract the base version.  — `filelib:wildcard(filename:join([Path, "releases", "*",  Name ++ ".rel"]))`. In this case, we always got `releases/0.1/dummy.rel`, NOT `releases/0.2/dummy_0.2.rel`. I think that is a mistake.

In this pull request, I use `releases/start_erl.data` as a source to get the permanent version, and make sure we could get the specific `relup` and `*.rel` file for upgrade.

Beside, now, we pass `NewName` to `systools:make_relup` (`run_systools/2` in `rebar_upgrade.erl` ).  That results in a mistake, I think, which leads `systool` to get NewName.rel every time. Again, in this case, `dummy_0.2` is right. So, before calling `run_systools`, I use wildcard `Name ++ "*.rel”` to expend the second parameter. Because in `sasl`, it calls `file:path_open/3` to read `.rel` file. If we pass `dummy_VERSION`, we could get the specific file.

Thanks for your reviewing.
