### PR TITLE
Fix eunit_surefire crash with rebar eunit tests=...

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -458,7 +458,7 @@ make_test_primitives(RawTests) ->
                             %% Generator
                             MakePrimitive(generator, M, F2)
                     end,
-                [NewFunction|Acc]
+                [eunit_module_suite(M, NewFunction)|Acc]
         end,
     lists:foldl(F, [], RawTests).
 
@@ -469,6 +469,11 @@ pre15b02_eunit_primitive(test, M, F) ->
     eunit_test:function_wrapper(M, F);
 pre15b02_eunit_primitive(generator, M, F) ->
     {generator, eunit_test:function_wrapper(M, F)}.
+
+% Add a test group for eunit_surefire to be able to deduce the testsuite.
+% Calling eunit:test({module, M}) does exactly this as well.
+eunit_module_suite(M, X) ->
+    {"module '" ++ atom_to_list(M) ++ "'", X}.
 
 %%
 %% == run tests ==


### PR DESCRIPTION
This fixes the following crash:

> =ERROR REPORT==== 20-Jun-2014::16:35:38 ===
> Error in process <0.40.0> with exit value:
{function_clause,[{eunit_surefire,escape_suitename,[undefined,[]],[{file,"eunit_surefire.erl"},{line,416}]},{eunit_surefire,write_report,2,[{file,"eunit_surefire.erl"},{line,258}]},{lists,foreach,2,[{file,"lists.erl"},{line,1336}]},{...