### PR TITLE
Moves ct_extra_params to the end of the generated ct_run command

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -120,3 +120,4 @@ Pedram Nimreezi
 Sylvain Benner
 Oliver Ferrigni
 Dave Thomas
+Drew Varner

--- a/inttest/ct1/app.config
+++ b/inttest/ct1/app.config
@@ -1,0 +1,2 @@
+%% This file is an application config file, not a CT test config file
+[{a1, [{foo, bar}]}].

--- a/inttest/ct1/ct1_rt.erl
+++ b/inttest/ct1/ct1_rt.erl
@@ -7,10 +7,12 @@ files() ->
     [{create, "ebin/a1.app", app(a1)},
      {copy, "../../rebar", "rebar"},
      {copy, "rebar.config", "rebar.config"},
+     {copy, "app.config", "app.config"},
      {copy, "test_SUITE.erl", "itest/test_SUITE.erl"}].
 
 run(_Dir) ->
     {ok, _} = retest:sh("./rebar compile ct"),
+    {ok, _} = retest:sh("./rebar compile ct -v"),
     ok.
 
 

--- a/inttest/ct1/rebar.config
+++ b/inttest/ct1/rebar.config
@@ -1,1 +1,2 @@
 {ct_dir, "itest"}.
+{ct_extra_params, "-repeat 2 -erl_args -config app"}.

--- a/inttest/ct1/test_SUITE.erl
+++ b/inttest/ct1/test_SUITE.erl
@@ -5,7 +5,13 @@
 -include_lib("ct.hrl").
 
 all() ->
-    [simple_test].
+    [simple_test,
+     app_config_file_test].
 
 simple_test(Config) ->
     io:format("Test: ~p\n", [Config]).
+
+app_config_file_test(_Config) ->
+    application:start(a1),
+    {ok, bar} = application:get_env(a1, foo),
+    application:stop(a1).

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -217,15 +217,13 @@ make_cmd(TestDir, RawLogDir, Config) ->
                        " ~s"
                        " ~s"
                        " -logdir \"~s\""
-                       " -env TEST_DIR \"~s\""
-                       " ~s",
+                       " -env TEST_DIR \"~s\"",
                        [BaseCmd,
                         CodePathString,
                         Include,
                         build_name(Config),
                         LogDir,
-                        filename:join(Cwd, TestDir),
-                        get_extra_params(Config)]) ++
+                        filename:join(Cwd, TestDir)]) ++
                       get_cover_config(Config, Cwd) ++
                       get_ct_config_file(TestDir) ++
                       get_config_file(TestDir) ++
@@ -237,19 +235,18 @@ make_cmd(TestDir, RawLogDir, Config) ->
                        " ~s"
                        " ~s"
                        " -logdir \"~s\""
-                       " -env TEST_DIR \"~s\""
-                       " ~s",
+                       " -env TEST_DIR \"~s\"",
                        [BaseCmd,
                         CodePathString,
                         Include,
                         build_name(Config),
                         LogDir,
-                        filename:join(Cwd, TestDir),
-                        get_extra_params(Config)]) ++
+                        filename:join(Cwd, TestDir)]) ++
                       SpecFlags ++ get_cover_config(Config, Cwd)
           end,
+    Cmd1 = Cmd ++ get_extra_params(Config),
     RawLog = filename:join(LogDir, "raw.log"),
-    {Cmd, RawLog}.
+    {Cmd1, RawLog}.
 
 build_name(Config) ->
     case rebar_config:get_local(Config, ct_use_short_names, false) of
@@ -258,7 +255,12 @@ build_name(Config) ->
     end.
 
 get_extra_params(Config) ->
-    rebar_config:get_local(Config, ct_extra_params, "").
+    case rebar_config:get_local(Config, ct_extra_params, undefined) of
+        undefined ->
+            "";
+        Defined ->
+            " " ++ Defined
+    end.
 
 get_ct_specs(Cwd) ->
     case collect_glob(Cwd, ".*\.test\.spec\$") of


### PR DESCRIPTION
This patch places `ct_extra_params` at the end of the generated `ct_run` command. This allows users to use `-erl_args` at the end and pass options directly to the emulator.

The integration test includes an example of how to pass a `ct_run` option followed by an `-erl_args` option:

`{ct_extra_params, "-repeat 2 -erl_args -config app"}.`

This should fix https://github.com/rebar/rebar/issues/271
