### PR TITLE
Protobuffs compiler take more opts other than just erl_opts

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -126,3 +126,4 @@ Yuki Ito
 alisdair sullivan
 Alexander Verbitsky
 Andras Horvath
+Zhibo Wei

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -89,6 +89,13 @@
 %% Options for the ErlyDTL compiler
 {erlydtl_opts, []}.
 
+%% == Protobuffs Compiler ==
+
+%% Options for the Protobuffs Erlang compiler
+%% Refer to https://github.com/basho/erlang_protobuffs for all
+%% available options
+{protobuffs_opts, []}.
+
 %% == EUnit ==
 
 %% Options for eunit:test()


### PR DESCRIPTION
Basically, this issue was brought up by https://github.com/rebar/rebar/pull/150 but it failed to get merged back. I did some improvements on that pull request and Im trying to bringing it up again since I believe it is pretty important for some ppl like me.