### PR TITLE
Add flag to ignore pre- and post-hooks

### DIFF
--- a/inttest/thooks_exclude/fish.erl
+++ b/inttest/thooks_exclude/fish.erl
@@ -1,0 +1,5 @@
+-module(fish).
+
+-compile(export_all).
+
+fish() -> fish.

--- a/inttest/thooks_exclude/rebar.config
+++ b/inttest/thooks_exclude/rebar.config
@@ -1,0 +1,7 @@
+%% pre-scripts
+{pre_hooks, [{clean, "echo preclean >> preclean.out"},
+             {compile, "echo precompile >> precompile.out"}]}.
+
+%% post-scripts
+{post_hooks, [{clean, "echo postclean >> postclean.out"},
+              {compile, "echo postcompile >> postcompile.out"}]}.

--- a/inttest/thooks_exclude/thooks_exclude_rt.erl
+++ b/inttest/thooks_exclude/thooks_exclude_rt.erl
@@ -1,0 +1,82 @@
+-module(thooks_exclude_rt).
+
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+files() ->
+    [
+     {copy, "../../rebar", "rebar"},
+     {copy, "rebar.config", "rebar.config"},
+     {copy, "fish.erl", "src/fish.erl"},
+     {create, "ebin/fish.app", app(fish, [fish])}
+    ].
+
+run(_Dir) ->
+    run_ignore_pre_hooks(),
+    run_ignore_post_hooks(),
+    run_ignore_hooks().
+
+run_ignore_pre_hooks() ->
+    clean(),
+    ?assertMatch({ok, _},
+      retest_sh:run("./rebar -v --ignore-pre-hooks clean compile", [])),
+    ensure_command_ran_never("preclean"),
+    ensure_command_ran_never("precompile"),
+    ensure_command_ran_only_once("postclean"),
+    ensure_command_ran_only_once("postcompile"),
+    ok.
+
+run_ignore_post_hooks() ->
+    clean(),
+    ?assertMatch({ok, _},
+      retest_sh:run("./rebar -v --ignore-post-hooks clean compile", [])),
+    ensure_command_ran_only_once("preclean"),
+    ensure_command_ran_only_once("precompile"),
+    ensure_command_ran_never("postclean"),
+    ensure_command_ran_never("postcompile"),
+    ok.
+
+run_ignore_hooks() ->
+    clean(),
+    ?assertMatch({ok, _},
+      retest_sh:run("./rebar -v --ignore-hooks clean compile", [])),
+    ensure_command_ran_never("preclean"),
+    ensure_command_ran_never("precompile"),
+    ensure_command_ran_never("postclean"),
+    ensure_command_ran_never("postcompile"),
+    ok.
+
+clean() ->
+    delete("preclean.out"),
+    delete("precompile.out"),
+    delete("postclean.out"),
+    delete("postcompile.out").
+
+delete(File) ->
+    case file:delete(File) of
+        ok -> ok;
+        {error, enoent} -> ok
+    end.
+
+ensure_command_ran_never(Command) ->
+    File = Command ++ ".out",
+    ?assertNot(filelib:is_file(File)).
+
+ensure_command_ran_only_once(Command) ->
+    File = Command ++ ".out",
+    ?assert(filelib:is_regular(File)),
+    %% ensure that this command only ran once (not for each module)
+    {ok, Content} = file:read_file(File),
+    ?assertEqual(Command ++ "\n", binary_to_list(Content)).
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).


### PR DESCRIPTION
Adds the ability to specify on the command line that pre-hooks
(--ignore-pre-hooks), post-hooks (--ignore-post-hooks), or both
(--ignore-hooks) should be ignored.

This can be useful when a hook is expensive to execute, and not needed for every compile or clean. For example, having relx as a post-compile hook, to create a release, which isn't needed when doing compiles during development.

Otherwise, one's rebar.config could be manually modified to remove the hooks until they're needed again, or a copy of the rebar.config could be maintained, without the hook, but those both require extra work.

Separate makefile targets can include or not include an --ignore-* flag. For example "make dev" can invoke "rebar --ignore-post-hooks compile", while "make release" can invoke "rebar compile" (to allow the normal hook execution).

inttest/thooks_exclude has been added to test this (based on the existing inttest/thooks)

No additional Dialyzer warnings are generated from these changes ("make check" on the current master results in about 15 warnings, however).
