### PR TITLE
Add details on Dialyzer with "make check"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ To do that, run `make check`. If you didn't build via `make debug` at first, the
 and [Dialyzer](http://www.erlang.org/doc/man/dialyzer.html), causing a test 
 failure.  
 If that happens, running `make clean` before running `make check` could solve the problem.  
+
+Dialyzer requires a PLT (Persitent Lookup Table) to work with. By default, it will look for  
+`$HOME/.dialyzer.plt` (alternatively, the `DIALYZER_PLT` environment variable can be set  
+to point to a different location). If a PLT file cannot be found, Dialyzer (via `make check`) will  
+fail- the output will indicate `"Could not read PLT file"`, including the path it tried to use.  
+See the [Dialyzer man page](http://www.erlang.org/doc/man/dialyzer.html) or [this further explanation](http://www.erlang.org/doc/apps/dialyzer/dialyzer_chapter.html) for details on creating the initial  
+PLT file.
+
 If you change any of the files with known but safe to ignore Dialyzer warnings, you may  
 have to adapt the line number(s) in [dialyzer_reference](dialyzer_reference). If you do that, 
 do not remove the  


### PR DESCRIPTION
If Dialyzer hasn't been used on an account before, there won't be a PLT
file and "make check" will fail. Added info on that fact to CONTRIBUTING.md.