### PR TITLE
fixing detecting deps dir for cover.spec files

### DIFF
--- a/inttest/deps_with_cover_spec_files/a.erl
+++ b/inttest/deps_with_cover_spec_files/a.erl
@@ -1,0 +1,6 @@
+-module(a).
+
+-compile(export_all).
+
+hello() ->
+    io:format("hello world\n").

--- a/inttest/deps_with_cover_spec_files/a.rebar.config
+++ b/inttest/deps_with_cover_spec_files/a.rebar.config
@@ -1,0 +1,2 @@
+{deps, [{b, "1", {git, "../repo/b"}}]}.
+{cover_enabled, true}.

--- a/inttest/deps_with_cover_spec_files/a_SUITE.erl
+++ b/inttest/deps_with_cover_spec_files/a_SUITE.erl
@@ -1,0 +1,8 @@
+-module(a_SUITE).
+
+-compile(export_all).
+
+all() -> [foo].
+
+foo(Config) ->
+    io:format("Test: ~p\n", [Config]).

--- a/inttest/deps_with_cover_spec_files/b.rebar.config
+++ b/inttest/deps_with_cover_spec_files/b.rebar.config
@@ -1,0 +1,2 @@
+{deps, [{c, "1", {git, "../repo/c"}}]}.
+{cover_enabled, true}.

--- a/inttest/deps_with_cover_spec_files/cover.spec
+++ b/inttest/deps_with_cover_spec_files/cover.spec
@@ -1,0 +1,1 @@
+{export, "./cover.data"}.

--- a/inttest/deps_with_cover_spec_files/deps_with_cover_spec_files_rt.erl
+++ b/inttest/deps_with_cover_spec_files/deps_with_cover_spec_files_rt.erl
@@ -1,0 +1,61 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+-module(deps_with_cover_spec_files_rt).
+
+-compile(export_all).
+
+files() ->
+    [
+     %% A application
+     {create, "ebin/a.app", app(a, [a])},
+     {copy, "a.rebar.config", "rebar.config"},
+     {copy, "a.erl", "src/a.erl"},
+     {copy, "a_SUITE.erl", "test/a_SUITE.erl"},
+     {copy, "cover.spec", "repo/a/cover.spec"},
+     {copy, "../../rebar", "rebar"},
+
+     %% B application
+     {create, "repo/b/ebin/b.app", app(b, [])},
+     {copy, "b.rebar.config", "repo/b/rebar.config"},
+     {copy, "cover.spec", "repo/b/cover.spec"},
+
+     %% C application
+     {create, "repo/c/ebin/c.app", app(c, [])},
+     {copy, "cover.spec", "repo/c/cover.spec"}
+    ].
+
+apply_cmds([], _Params) ->
+    ok;
+apply_cmds([Cmd | Rest], Params) ->
+    io:format("Running: ~s (~p)\n", [Cmd, Params]),
+    {ok, _} = retest_sh:run(Cmd, Params),
+    apply_cmds(Rest, Params).
+
+run(_Dir) ->
+    %% Initialize the b/c apps as git repos so that dependencies pull
+    %% properly
+    GitCmds = ["git init",
+               "git add -A",
+               "git config user.email 'deps_with_cover_spec_files@example.com'",
+               "git config user.name 'deps_with_cover_spec_files'",
+               "git commit -a -m 'Initial Commit'"],
+    apply_cmds(GitCmds, [{dir, "repo/b"}]),
+    apply_cmds(GitCmds, [{dir, "repo/c"}]),
+    {ok, _} = retest_sh:run("./rebar get-deps", []),
+    %% Remove the repos, so cover.spec files are not found when running the tests.
+    apply_cmds(["rm -rf a b c"], [{dir, "repo"}]),
+    %% This should fail if more than 1 cover.spec file is found.
+    {ok, _} = retest:sh("./rebar compile ct -vv"),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -291,24 +291,14 @@ get_cover_config(Config, Cwd) ->
 
 collect_glob(Config, Cwd, Glob) ->
     {true, Deps} = rebar_deps:get_deps_dir(Config),
-    CwdParts = filename:split(Cwd),
     filelib:fold_files(Cwd, Glob, true, fun(F, Acc) ->
-        %% Ignore any specs under the deps/ directory. Do this pulling
-        %% the dirname off the F and then splitting it into a list.
-        Parts = filename:split(filename:dirname(F)),
-        Parts2 = remove_common_prefix(Parts, CwdParts),
-        case lists:member(Deps, Parts2) of
-            true ->
+        case string:substr(F, 1, length(Deps)) of
+            Deps ->
                 Acc;                % There is a directory named "deps" in path
-            false ->
+            _ ->
                 [F | Acc]           % No "deps" directory in path
         end
     end, []).
-
-remove_common_prefix([H1|T1], [H1|T2]) ->
-    remove_common_prefix(T1, T2);
-remove_common_prefix(L1, _) ->
-    L1.
 
 get_ct_config_file(TestDir) ->
     Config = filename:join(TestDir, "test.config"),


### PR DESCRIPTION
Hey guys,

I've hit a *possible* a bug when trying to run ct tests with deps that have a cover.spec file. It seems that collect_glob/3 does not correctly determine that it should skip a cover.spec file inside a dependency directory and it ends up seeing all available cover.spec files (the one for the root project and the ones inside their deps).

This patch seems to work ok. 

Any thoughts about it?

Thanks in advance!