### PR TITLE
debrain broken version check

### DIFF
--- a/src/rebar_reltool.erl
+++ b/src/rebar_reltool.erl
@@ -116,7 +116,7 @@ check_vsn() ->
         {error, bad_name} ->
             ?ABORT("Reltool support requires the reltool application "
                    "to be installed!", []);
-        Path ->
+        _ ->
             ok
     end.
 


### PR DESCRIPTION
Perhaps not an ideal fix, but wanted to at least raise the issue in this PR. Was getting

```
==> rel (generate)
ERROR: Reltool support requires at least reltool-0.5.2; this VM is using reltool
```

As it turns out, `ReltoolVsn` was just `reltool` for my built-from-src OTP 17.0 

(Bonus inclusion: trailing whitespace my editor found and excised)
