### PR TITLE
Fix CT suites crashing when deps have coverspec

### DIFF
--- a/inttest/ct_cover/ct_cover_rt.erl
+++ b/inttest/ct_cover/ct_cover_rt.erl
@@ -1,0 +1,16 @@
+-module(ct_cover_rt).
+
+-compile(export_all).
+
+
+files() ->
+    [{copy, "../../rebar", "rebar"},
+     {copy, "src", "src"},
+     {copy, "test", "test"},
+     {copy, "deps", "deps"},
+     {copy, "rebar.config", "rebar.config"}].
+
+
+run(_Dir) ->
+    {ok, _} = retest:sh("./rebar compile ct -vv"),
+    ok.

--- a/inttest/ct_cover/deps/foodep/src/foodep.app.src
+++ b/inttest/ct_cover/deps/foodep/src/foodep.app.src
@@ -1,0 +1,12 @@
+{application, foodep,
+ [
+  {description, ""},
+  {vsn, "1"},
+  {registered, []},
+  {applications, [
+                  kernel,
+                  stdlib
+                 ]},
+  {mod, {foodep, []}},
+  {env, []}
+ ]}.

--- a/inttest/ct_cover/deps/foodep/src/foodep.erl
+++ b/inttest/ct_cover/deps/foodep/src/foodep.erl
@@ -1,0 +1,6 @@
+-module(foodep).
+
+-export([foodep/0]).
+
+foodep() ->
+    true =:= true.

--- a/inttest/ct_cover/deps/foodep/test/ct.cover.spec
+++ b/inttest/ct_cover/deps/foodep/test/ct.cover.spec
@@ -1,0 +1,2 @@
+{level, details}.
+{mods, [foodep]}.

--- a/inttest/ct_cover/deps/foodep/test/foodep_SUITE.erl
+++ b/inttest/ct_cover/deps/foodep/test/foodep_SUITE.erl
@@ -1,0 +1,12 @@
+-module(foodep_SUITE).
+
+-compile(export_all).
+
+-include_lib("ct.hrl").
+
+all() ->
+    [foodep_test].
+
+foodep_test(Config) ->
+    true =:= foodep:foodep(),
+    ok.

--- a/inttest/ct_cover/rebar.config
+++ b/inttest/ct_cover/rebar.config
@@ -1,0 +1,4 @@
+{deps, [{foodep, "1"}]}.
+{cover_enabled, true}.
+{ct_dir, "test"}.
+% {ct_extra_params, "-repeat 2 -erl_args -config app"}.

--- a/inttest/ct_cover/src/foo.app.src
+++ b/inttest/ct_cover/src/foo.app.src
@@ -1,0 +1,12 @@
+{application, foo,
+ [
+  {description, ""},
+  {vsn, "1"},
+  {registered, []},
+  {applications, [
+                  kernel,
+                  stdlib
+                 ]},
+  {mod, {foo, []}},
+  {env, []}
+ ]}.

--- a/inttest/ct_cover/src/foo.erl
+++ b/inttest/ct_cover/src/foo.erl
@@ -1,0 +1,6 @@
+-module(foo).
+
+-export([foo/0]).
+
+foo() ->
+    true =:= true.

--- a/inttest/ct_cover/test/ct.cover.spec
+++ b/inttest/ct_cover/test/ct.cover.spec
@@ -1,0 +1,2 @@
+{level, details}.
+{mods, [foo]}.

--- a/inttest/ct_cover/test/foo_SUITE.erl
+++ b/inttest/ct_cover/test/foo_SUITE.erl
@@ -1,0 +1,12 @@
+-module(foo_SUITE).
+
+-compile(export_all).
+
+-include_lib("ct.hrl").
+
+all() ->
+    [foo_test].
+
+foo_test(Config) ->
+    true =:= foo:foo(),
+    ok.


### PR DESCRIPTION
This fixes a bug introduced in commit 5e91322e4ab0383068463844ead85ff15c0fba9e that causes rebar ct to fail when running where a dependency also has a cover.spec file.