### PR TITLE
Fix cover print truncation when coverage is 100%

### DIFF
--- a/src/rebar_cover_utils.erl
+++ b/src/rebar_cover_utils.erl
@@ -238,7 +238,7 @@ print_coverage(Coverage) ->
     %% Print the output the console
     ?CONSOLE("~nCode Coverage:~n", []),
     lists:foreach(fun({Mod, C, N}) ->
-                          ?CONSOLE("~*s : ~3s~n",
+                          ?CONSOLE("~*s : ~4s~n",
                                    [Width, Mod, percentage(C, N)])
                   end, Coverage),
     ?CONSOLE("~n~*s : ~s~n", [Width, "Total", TotalCoverage]).


### PR DESCRIPTION
When the option `{cover_print_enabled, true}` is set and that the code
coverage is 100%, the '%' will end up being truncated.

This patch makes it so that the truncation happens at 4 a characters
width so that instead of the following printouts:

```
some_mod  : 99%
some_other: 100
```

We instead show:

```
some_mod  :  99%
some_other: 100%
```

This solves issue #331 as reported by @lispking and @NineFX.
