### PR TITLE
Update format_source function to match all possible source types

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -128,3 +128,4 @@ Alexander Verbitsky
 Andras Horvath
 Drew Varner
 Roberto Aloi
+Pavel Baturko

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -816,5 +816,7 @@ format_source(App, {git, Url, {tag, Tag}}) ->
     ?FMT("~p TAG ~s ~s", [App, Tag, Url]);
 format_source(App, {_, Url, Rev}) ->
     ?FMT("~p REV ~s ~s", [App, Rev, Url]);
+format_source(App, {SrcType, Url}) ->
+    ?FMT("~p ~p ~s", [App, SrcType, Url]);
 format_source(App, undefined) ->
     ?FMT("~p", [App]).


### PR DESCRIPTION
With some types of dependency sources in rebar.config file list-deps command will crashes with function clause.
Added another variant of format_source to match missed source types.
