### PR TITLE
Remove check adding ebin to path for edoc target

### DIFF
--- a/src/rebar_edoc.erl
+++ b/src/rebar_edoc.erl
@@ -87,7 +87,7 @@ setup_code_path() ->
     %% and the like can work properly when generating their own
     %% documentation.
     CodePath = code:get_path(),
-    true = code:add_patha(rebar_utils:ebin_dir()),
+    _ = code:add_patha(rebar_utils:ebin_dir()),
     CodePath.
 
 -type path_spec() :: {'file', file:filename()} | file:filename().


### PR DESCRIPTION
edoc target will fail if ebin directory does not exist. ebin directory is not necessary for building edoc so check that ebin exist and added to path can be skipped.
