### PR TITLE
deps: fix delete-deps if deps_dir ends with dot

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -307,8 +307,9 @@ get_deps_dir(Config) ->
 
 get_deps_dir(Config, App) ->
     BaseDir = rebar_utils:base_dir(Config),
-    DepsDir = get_shared_deps_dir(Config, "deps"),
-    {true, filename:join([BaseDir, DepsDir, App])}.
+    DepsDir0 = get_shared_deps_dir(Config, "deps"),
+    DepsDir = filename:dirname(filename:join([BaseDir, DepsDir0, "dummy"])),
+    {true, filename:join([DepsDir, App])}.
 
 dep_dirs(Deps) ->
     [D#dep.dir || D <- Deps].


### PR DESCRIPTION
Remove possible last dot from deps dir path by adding
slash to value deps_dir from config.
With this fix delete-deps command deletes dependencies
properly in case of deps dir path ended with dot.
Examples of deps_dir config value that triggers error:
".", "some/path/.".
Code that triggers error: rebar_deps:'delete-deps'/2,
code line lists:prefix(DepsDir, D#dep.dir).
If deps_dir = ".", cwd = "/root", dependency name = "app"
then DepsDir = "/root/." and D#dep.dir = "/root/app" so
prefix fun returns false but should be true.
Dependency app will not be removed because of this.
If symbol "/" is added to the deps_dir path last dot will
be removed by filename:join/1 in get_deps_dir/2.