### PR TITLE
Add support for .tar.gz and .tar.bz2 dependencies

### DIFF
--- a/ebin/rebar.app
+++ b/ebin/rebar.app
@@ -51,7 +51,10 @@
                   compiler,
                   crypto,
                   syntax_tools,
-                  tools]},
+                  tools,
+                  public_key,
+                  ssl,
+                  inets]},
   {env, [
          %% Default log level
          {log_level, warn},


### PR DESCRIPTION
Hi!,

 I would find the support for .tar.gz and .tar.bz2 files very useful for my project. It just download and decompress the sources from the provided URL.
