### PR TITLE
Increase the timeout for the inttest/proto_gpb

### DIFF
--- a/inttest/proto_gpb/retest.config
+++ b/inttest/proto_gpb/retest.config
@@ -1,0 +1,5 @@
+%% On my slow old netbook with a 1.6GHz CPU, this inttest
+%% takes about 40 seconds to run, of which network activity
+%% is about 3s. Double that to make avoid unnecessary timeouts
+%% on e.g. loaded shared hosts, or with slow network connections.
+{timeout, 90000}.


### PR DESCRIPTION
On my slow old netbook with a 1.6GHz CPU, this inttest
takes about 40 seconds to run, of which network activity
is about 3s, the default timeout of retest is 30s.
Add a generous margin to avoid unnecessary timeouts.
