### PR TITLE
add Emacs/vi header to non-dummy test modules

### DIFF
--- a/inttest/bug_5_rt.erl
+++ b/inttest/bug_5_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(bug_5_rt).
 
 -compile(export_all).

--- a/inttest/ct1/ct1_rt.erl
+++ b/inttest/ct1/ct1_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(ct1_rt).
 
 -compile(export_all).

--- a/inttest/ct2/ct2_rt.erl
+++ b/inttest/ct2/ct2_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(ct2_rt).
 
 -compile(export_all).

--- a/inttest/depplugins/depplugins_rt.erl
+++ b/inttest/depplugins/depplugins_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 %%% @doc Plugin handling test
 %%%
 %%% This test checks if plugins are loaded correctly.

--- a/inttest/eunit/eunit_rt.erl
+++ b/inttest/eunit/eunit_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(eunit_rt).
 -export([files/0, run/1]).
 

--- a/inttest/rgen1/rgen1_rt.erl
+++ b/inttest/rgen1/rgen1_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(rgen1_rt).
 
 -compile(export_all).

--- a/inttest/t_custom_config/t_custom_config_rt.erl
+++ b/inttest/t_custom_config/t_custom_config_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(t_custom_config_rt).
 
 -compile(export_all).

--- a/inttest/tdeps1/tdeps1_rt.erl
+++ b/inttest/tdeps1/tdeps1_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(tdeps1_rt).
 
 -compile(export_all).

--- a/inttest/tdeps2/tdeps2_rt.erl
+++ b/inttest/tdeps2/tdeps2_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(tdeps2_rt).
 
 -compile(export_all).

--- a/inttest/tdeps3/tdeps3_rt.erl
+++ b/inttest/tdeps3/tdeps3_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(tdeps3_rt).
 
 -compile(export_all).

--- a/inttest/tdeps_update/tdeps_update_rt.erl
+++ b/inttest/tdeps_update/tdeps_update_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(tdeps_update_rt).
 
 -compile(export_all).

--- a/inttest/thooks/thooks_rt.erl
+++ b/inttest/thooks/thooks_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(thooks_rt).
 
 -include_lib("eunit/include/eunit.hrl").

--- a/inttest/tplugins/tplugins_rt.erl
+++ b/inttest/tplugins/tplugins_rt.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(tplugins_rt).
 -compile(export_all).
 

--- a/test/rebar_require_vsn_tests.erl
+++ b/test/rebar_require_vsn_tests.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(rebar_require_vsn_tests).
 
 -compile(export_all).

--- a/test/rebar_xref_eunit.erl
+++ b/test/rebar_xref_eunit.erl
@@ -1,3 +1,5 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
 -module(rebar_xref_eunit).
 
 -compile(export_all).


### PR DESCRIPTION
Some files were missing the headers specifying the indentation settings. 
This can create dummy diffs if reindenting all code at once.
