### PR TITLE
fix target dir without subdir for erlydtl templates

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -107,8 +107,7 @@ target_file(SourceFile, SourceDir, SourceExt, TargetDir, TargetExt) ->
     %% Remove all leading components of the source dir from the file -- we want
     %% to maintain the deeper structure (if any) of the source file path
     BaseFile = remove_common_path(SourceFile, SourceDir),
-    filename:join([TargetDir, filename:dirname(BaseFile),
-                   filename:basename(BaseFile, SourceExt) ++ TargetExt]).
+    filename:join([TargetDir, filename:basename(BaseFile, SourceExt) ++ TargetExt]).
 
 
 remove_common_path(Fname, Path) ->


### PR DESCRIPTION
When you compile erlydtl templates with recursive structure last modification of compiled files always undefined, because template_dir/subdir/template.ext != ebin/subdir/template_ext.beam
Target must be without subdirs
