### PR TITLE
Fix deps path check in rebar_ct:collect_glob/3

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -130,3 +130,4 @@ Drew Varner
 Roberto Aloi
 Luis Rascao
 Vlad Dumitrescu
+stwind

--- a/inttest/ct2/deps/bar.test.spec
+++ b/inttest/ct2/deps/bar.test.spec
@@ -1,0 +1,1 @@
+%% this test spec should be ignored

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -291,13 +291,14 @@ get_cover_config(Config, Cwd) ->
 
 collect_glob(Config, Cwd, Glob) ->
     {true, Deps} = rebar_deps:get_deps_dir(Config),
+    DepsDir = filename:basename(Deps),
     CwdParts = filename:split(Cwd),
     filelib:fold_files(Cwd, Glob, true, fun(F, Acc) ->
         %% Ignore any specs under the deps/ directory. Do this pulling
         %% the dirname off the F and then splitting it into a list.
         Parts = filename:split(filename:dirname(F)),
         Parts2 = remove_common_prefix(Parts, CwdParts),
-        case lists:member(Deps, Parts2) of
+        case lists:member(DepsDir, Parts2) of
             true ->
                 Acc;                % There is a directory named "deps" in path
             false ->


### PR DESCRIPTION
Since `rebar_deps:get_deps_dir/1`  returns an absolute path, `lists:member(Deps, Parts2)` will always return false.
