### PR TITLE
gpb_compile: restore missing gpb proto compile message

### DIFF
--- a/src/rebar_proto_gpb_compiler.erl
+++ b/src/rebar_proto_gpb_compiler.erl
@@ -118,7 +118,8 @@ compile_gpb(Source, GpbOpts) ->
         {error, _Reason} ->
             ?ERROR("Failed to compile ~s~n", [Source]),
             ?FAIL
-    end.
+    end,
+    ?CONSOLE("Compiled ~s\n", [Source]).
 
 beam_file(ProtoFile, GpbOpts) ->
     proto_filename_to_path("ebin", ProtoFile, ".beam", GpbOpts).


### PR DESCRIPTION
Conjunction of pull requests #386 and #408 (8f64e1, 81063d) led to compilation message being removed.

#408 removed the compilation message based on the fact that proto gpb compilation was making use of rebar's base compiler, #386 stopped making use of rebar's base compiler to overcome correct dependency checking issue.