### PR TITLE
Transform list of unicode chars in templater

### DIFF
--- a/inttest/rgen1/test.config
+++ b/inttest/rgen1/test.config
@@ -1,1 +1,2 @@
 {web_port, {{web_port}} }.
+{non_ascii_var, {{non_ascii_var}} }.

--- a/inttest/rgen1/vars.config
+++ b/inttest/rgen1/vars.config
@@ -1,1 +1,2 @@
 {web_port, 1234}.
+{non_ascii_var, "\"zażółć gęślą jaźń\""}.

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -87,7 +87,13 @@ create(Config, _) ->
 resolve_variables([], Dict) ->
     Dict;
 resolve_variables([{Key, Value0} | Rest], Dict) when is_list(Value0) ->
-    Value = render(list_to_binary(Value0), Dict),
+    Value1 = case rebar_utils:otp_release() of
+        [$R|_] ->
+            list_to_binary(Value0);
+        _ ->
+            unicode:characters_to_binary(Value0)
+    end,
+    Value = render(Value1, Dict),
     resolve_variables(Rest, dict:store(Key, Value, Dict));
 resolve_variables([{Key, {list, Dicts}} | Rest], Dict) when is_list(Dicts) ->
     %% just un-tag it so mustache can use it


### PR DESCRIPTION
Since OTP 17 strings read from a file are by default parsed as a list of
unicode characters.
If such a list contains a non-ascii character (unicode > 255) then a
call to erlang:list_to_binary/1 fails.
This commit converts unicode list of chars to binary via unicode module
if ran against OTP >= 17.