### PR TITLE
Gpb recompilation detection (using base compiler)

### DIFF
--- a/inttest/proto_gpb/proto_gpb_rt.erl
+++ b/inttest/proto_gpb/proto_gpb_rt.erl
@@ -79,6 +79,12 @@ run(_Dir) ->
     TestMTime2 = read_mtime(TestErl),
     ?assert(TestMTime2 > TestMTime1),
 
+    ?DEBUG("Verifying recompilation with no changes~n", []),
+    TestMTime3 = read_mtime(TestErl),
+    ?assertMatch({ok, _}, retest_sh:run("./rebar compile", [])),
+    TestMTime4 = read_mtime(TestErl),
+    ?assert(TestMTime3 =:= TestMTime4),
+
     ?DEBUG("Verify cleanup~n", []),
     ?assertMatch({ok, _}, retest_sh:run("./rebar clean", [])),
     ok = check_files_deleted(),

--- a/rebar.config
+++ b/rebar.config
@@ -26,6 +26,7 @@
       - (\"neotoma\":\"file\"/\"2\")
       - (\"protobuffs_compile\":\"scan_file\"/\"2\")
       - (\"gpb_compile\":\"file\"/\"2\")
+      - (\"gpb_compile\":\"format_error\"/\"1\")
       - (\"diameter_codegen\":\"from_dict\"/\"4\")
       - (\"diameter_dict_util\":\"format_error\"/\"1\")
       - (\"diameter_dict_util\":\"parse\"/\"2\"))",

--- a/src/rebar_appups.erl
+++ b/src/rebar_appups.erl
@@ -69,8 +69,8 @@
     {_Added, _Removed, Upgraded} = get_apps(Name, OldVerPath, NewVerPath),
 
     %% Get a list of any appup files that exist in the new release
-    NewAppUpFiles = rebar_utils:find_files(
-                      filename:join([NewVerPath, "lib"]), "^[^._].*.appup$"),
+    NewAppUpFiles = rebar_utils:find_files_by_ext(
+                      filename:join([NewVerPath, "lib"]), ".appup"),
 
     %% Convert the list of appup files into app names
     AppUpApps = [file_to_name(File) || File <- NewAppUpFiles],

--- a/src/rebar_proto_compiler.erl
+++ b/src/rebar_proto_compiler.erl
@@ -44,7 +44,7 @@
 %% ===================================================================
 
 compile(Config, AppFile) ->
-    case rebar_utils:find_files("src", "^[^._].*\\.proto$") of
+    case rebar_utils:find_files_by_ext("src", ".proto", true) of
         [] ->
             ok;
         Protos ->
@@ -56,7 +56,7 @@ compile(Config, AppFile) ->
 
 clean(Config, AppFile) ->
     %% Get a list of generated .beam and .hrl files and then delete them
-    Protos = rebar_utils:find_files("src", "^[^._].*\\.proto$"),
+    Protos = rebar_utils:find_files_by_ext("src", ".proto", true),
     case Protos of
         [] ->
             ok;

--- a/src/rebar_proto_compiler.erl
+++ b/src/rebar_proto_compiler.erl
@@ -44,7 +44,7 @@
 %% ===================================================================
 
 compile(Config, AppFile) ->
-    case rebar_utils:find_files_by_ext("src", ".proto", true) of
+    case rebar_utils:find_files_by_ext("src", ".proto") of
         [] ->
             ok;
         Protos ->
@@ -56,7 +56,7 @@ compile(Config, AppFile) ->
 
 clean(Config, AppFile) ->
     %% Get a list of generated .beam and .hrl files and then delete them
-    Protos = rebar_utils:find_files_by_ext("src", ".proto", true),
+    Protos = rebar_utils:find_files_by_ext("src", ".proto"),
     case Protos of
         [] ->
             ok;

--- a/src/rebar_qc.erl
+++ b/src/rebar_qc.erl
@@ -211,7 +211,7 @@ qc_module(QC=eqc, [], M) -> QC:module(M);
 qc_module(QC=eqc, QCOpts, M) -> QC:module(QCOpts, M).
 
 find_prop_mods() ->
-    Beams = rebar_utils:find_files(?QC_DIR, "^[^._].*\\.beam\$"),
+    Beams = rebar_utils:find_files_by_ext(?QC_DIR, ".beam"),
     [M || M <- [rebar_utils:erl_to_mod(Beam) || Beam <- Beams], has_prop(M)].
 
 has_prop(Mod) ->

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -242,11 +242,10 @@ find_escript_templates(Files) ->
 
 find_disk_templates(Config) ->
     OtherTemplates = find_other_templates(Config),
-    HomeFiles = rebar_utils:find_files(filename:join([os:getenv("HOME"),
-                                                      ".rebar", "templates"]),
-                                       ?TEMPLATE_RE),
+    HomeTemplates = filename:join([os:getenv("HOME"), ".rebar", "templates"]),
+    HomeFiles = rebar_utils:find_files_by_ext(HomeTemplates, ".template"),
     Recursive = rebar_config:is_recursive(Config),
-    LocalFiles = rebar_utils:find_files(".", ?TEMPLATE_RE, Recursive),
+    LocalFiles = rebar_utils:find_files_by_ext(".", ".template", Recursive),
     [{file, F} || F <- OtherTemplates ++ HomeFiles ++ LocalFiles].
 
 find_other_templates(Config) ->
@@ -254,7 +253,7 @@ find_other_templates(Config) ->
         undefined ->
             [];
         TemplateDir ->
-            rebar_utils:find_files(TemplateDir, ?TEMPLATE_RE)
+            rebar_utils:find_files_by_ext(TemplateDir, ".template")
     end.
 
 select_template([], Template) ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -34,6 +34,8 @@
          sh_send/3,
          find_files/2,
          find_files/3,
+         find_files_by_ext/2,
+         find_files_by_ext/3,
          now_str/0,
          ensure_dir/1,
          beam_to_mod/2,
@@ -159,6 +161,28 @@ find_files(Dir, Regex) ->
 find_files(Dir, Regex, Recursive) ->
     filelib:fold_files(Dir, Regex, Recursive,
                        fun(F, Acc) -> [F | Acc] end, []).
+
+%% Find files by extension, for example ".erl", avoiding resource fork
+%% files in OS X.  Such files are named for example src/._xyz.erl
+%% Such files may also appear with network filesystems on OS X.
+%%
+%% The Ext is really a regexp, with any leading dot implicitly
+%% escaped, and anchored at the end of the string.
+%%
+find_files_by_ext(Dir, Ext) ->
+    find_files_by_ext(Dir, Ext, true).
+
+find_files_by_ext(Dir, Ext, Recursive) ->
+    %% Convert simple extension to proper regex
+    EscapeDot = case Ext of
+                    "." ++ _ ->
+                        "\\";
+                    _ ->
+                        %% allow for other suffixes, such as _pb.erl
+                        ""
+                end,
+    ExtRe = "^[^._].*" ++ EscapeDot ++ Ext ++ [$$],
+    find_files(Dir, ExtRe, Recursive).
 
 now_str() ->
     {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:local_time(),


### PR DESCRIPTION
This is a second attempt at solving the #384, this time it uses the `rebar_base_compiler` for compiling. (The first attempt, was #386, which was reverted by #413)

The gpb supports both module name prefixes and suffixes, so the `rebar_base_compiler` has been extended to support this. So now in addition to the previous way of specifying source file name extension and target extension, it is now also possible to specify a `{Source,Target}` file names in full, as per the idea by @tuncer, in discussion also with @lrascao. The old way still works.

Now the proto compiler needs to find files by extension, so the `rebar_utils` has been extended with `find_files_by_ext/2,3`, which runs a regexp search to avoid OS X resource fork files. All relavent calls to `rebar_utils:find_files/2,3` have now been changed into `rebar_utils:find_files_by_ext/2,3` instead. In fact, the vast majority of the calls tried to find files by extension. One commit introduces `rebar_utils:find_files_by_ext/2,3`, and another commit changes all calls, as per suggestion by @tuncer. These two are the first commits on the branch.

An additional inttest has been added, by @lrascao to verify that nothing is recompiled when nothing has changed.

The commits on the branch have been discussed via mail with @tuncer and @lrascao prior to submission.