### PR TITLE
Copy instead of rsync gpb and protobuffs inttest mocks

### DIFF
--- a/inttest/proto_gpb/proto_gpb_rt.erl
+++ b/inttest/proto_gpb/proto_gpb_rt.erl
@@ -48,11 +48,11 @@ files() ->
      {copy, "rebar.config", "rebar.config"},
      {copy, "include", "include"},
      {copy, "src", "src"},
+     {copy, "mock", "deps"},
      {create, "ebin/foo.app", app(foo, ?MODULES ++ ?GENERATED_MODULES)}
     ].
 
 run(_Dir) ->
-    ?assertMatch({ok, _}, retest_sh:run("./rebar prepare-deps", [])),
     ?assertMatch({ok, _}, retest_sh:run("./rebar clean", [])),
     ?assertMatch({ok, _}, retest_sh:run("./rebar compile", [])),
     %% Foo includes test_gpb.hrl,

--- a/inttest/proto_gpb/rebar.config
+++ b/inttest/proto_gpb/rebar.config
@@ -8,7 +8,13 @@
 
 {deps,
  [
-  {gpb, [], {rsync, "../../../inttest/proto_gpb/mock/gpb"}}
+  %% The dependency below to gpb is needed for "rebar compile" to
+  %% work, thus for the inttest to work, but the gpb that is actually
+  %% used in inttest is brought in from the inttest/proto_gpb/mock
+  %% subdirectory, not from the source below.  The dependency is
+  %% needed, but the git url serves mostly as an example.
+  {gpb, [], {git, "git://github.com/tomas-abrahamsson/gpb",
+             {branch, "master"}}}
  ]}.
 
 {proto_compiler, gpb}.

--- a/inttest/proto_protobuffs/proto_protobuffs_rt.erl
+++ b/inttest/proto_protobuffs/proto_protobuffs_rt.erl
@@ -48,11 +48,11 @@ files() ->
      {copy, "rebar.config", "rebar.config"},
      {copy, "include", "include"},
      {copy, "src", "src"},
+     {copy, "mock", "deps"},
      {create, "ebin/foo.app", app(foo, ?MODULES)}
     ].
 
 run(_Dir) ->
-    ?assertMatch({ok, _}, retest_sh:run("./rebar prepare-deps", [])),
     ?assertMatch({ok, _}, retest_sh:run("./rebar clean", [])),
     ?assertMatch({ok, _}, retest_sh:run("./rebar compile", [])),
     ok = check_beams_generated(),

--- a/inttest/proto_protobuffs/rebar.config
+++ b/inttest/proto_protobuffs/rebar.config
@@ -8,7 +8,13 @@
 
 {deps,
  [
-  {protobuffs, [], {rsync, "../../../inttest/proto_protobuffs/mock/protobuffs"}}
+  %% The dependency below to protobuffs is needed for "rebar compile" to
+  %% work, thus for the inttest to work, but the protobuffs that is actually
+  %% used in inttest is brought in from the inttest/proto_protobuffs/mock
+  %% subdirectory, not from the source below.  The dependency is
+  %% needed, but the git url serves mostly as an example.
+  {protobuffs, [], {git, "git://github.com/basho/erlang_protobuffs",
+                    {branch, "master"}}}
  ]}.
 
 %% The default proto compiler is protobuffs


### PR DESCRIPTION
This is a PR for one more commit on the same branch as in #420, to implement @tuncer's idea to replace a dependency to rsync, with retest's functionality to copy files and directories. This for the proto_gpb and proto_protobuffs inttests.

Previously, in the respective `rebar.config`'s, there was a dependency with an `rsync` source to `../../../inttest/proto_gpb/mock`. Now this is instead done with a copy directive in the `proto_gpb_rt:files/0`. Ditto for protobuffs.

This eliminates a dependency to rsync from the inttest, and also, it removes knowledge about internal details about retest's directory layout.