### PR TITLE
Fixed #133. Release upgrade now handle long and short names properly.

### DIFF
--- a/priv/templates/simplenode.nodetool
+++ b/priv/templates/simplenode.nodetool
@@ -109,9 +109,27 @@ main(Args) ->
                 {value, Value, _Bindings} ->
                     io:format("~p\n", [Value])
             end;
+        ["upgrade", ReleasePackage] ->
+            %% TODO: This script currently does NOT support slim releases.
+            %% Necessary steps to upgrade a slim release are as follows:
+            %% 1. unpack relup archive manually
+            %% 2. copy releases directory and necessary libraries
+            %% 3. using release_hander:set_unpacked/2 .
+            %% For more details, see https://github.com/rebar/rebar/pull/52
+            %% and https://github.com/rebar/rebar/issues/202
+            {ok, Vsn} = rpc:call(TargetNode, release_handler, unpack_release,
+                                 [ReleasePackage], 60000),
+            io:format("Unpacked Release ~p\n", [Vsn]),
+            {ok, OtherVsn, Desc} = rpc:call(TargetNode, release_handler,
+                                            check_install_release, [Vsn], 60000),
+            {ok, OtherVsn, Desc} = rpc:call(TargetNode, release_handler,
+                                            install_release, [Vsn], 60000),
+            io:format("Installed Release ~p\n", [Vsn]),
+            ok = rpc:call(TargetNode, release_handler, make_permanent, [Vsn], 60000),
+            io:format("Made Release ~p Permanent\n", [Vsn]);
         Other ->
             io:format("Other: ~p\n", [Other]),
-            io:format("Usage: nodetool {chkconfig|getpid|ping|stop|restart|reboot|rpc|rpc_infinity|rpcterms|eval}\n")
+            io:format("Usage: nodetool {chkconfig|getpid|ping|stop|restart|reboot|rpc|rpc_infinity|rpcterms|eval|upgrade}\n")
     end,
     net_kernel:stop().
 

--- a/priv/templates/simplenode.reltool.config
+++ b/priv/templates/simplenode.reltool.config
@@ -38,6 +38,7 @@
            {copy, "files/{{nodeid}}", "bin/{{nodeid}}"},
            {copy, "files/{{nodeid}}.cmd", "bin/{{nodeid}}.cmd"},
            {copy, "files/start_erl.cmd", "bin/start_erl.cmd"},
+           %% Following line may be safely removed in new projects
            {copy, "files/install_upgrade.escript", "bin/install_upgrade.escript"},
            {copy, "files/sys.config", "releases/\{\{rel_vsn\}\}/sys.config"},
            {copy, "files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"}

--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -335,10 +335,7 @@ case "$1" in
             exit $ES
         fi
 
-        node_name=`echo $NAME_ARG | awk '{print $2}'`
-        erlang_cookie=`echo $COOKIE_ARG | awk '{print $2}'`
-
-        $ERTS_PATH/escript $RUNNER_BASE_DIR/bin/install_upgrade.escript $node_name $erlang_cookie $2
+        $NODETOOL upgrade $2
         ;;
 
     console|console_clean|console_boot)

--- a/priv/templates/simplenode.windows.runner.cmd
+++ b/priv/templates/simplenode.windows.runner.cmd
@@ -95,7 +95,7 @@ start "%node_name% attach" %werl% -boot "%clean_boot_script%" -remsh %node_name%
     @echo NOTE {package base name} MUST NOT include the .tar.gz suffix
     @goto :EOF
 )
-@%escript% %node_root%\bin\install_upgrade.escript %node_name% %erlang_cookie% %2
+@%escript% %nodetool% -sname "%node_name%" -setcookie "%erlang_cookie%" upgrade %2
 @goto :EOF
 
 :set_trim

--- a/test/upgrade_project/rel/files/dummy
+++ b/test/upgrade_project/rel/files/dummy
@@ -276,10 +276,7 @@ case "$1" in
             exit $ES
         fi
 
-        node_name=`echo $NAME_ARG | awk '{print $2}'`
-        erlang_cookie=`echo $COOKIE_ARG | awk '{print $2}'`
-
-        $ERTS_PATH/escript $RUNNER_BASE_DIR/bin/install_upgrade.escript $node_name $erlang_cookie $2
+        $NODETOOL upgrade $2
         ;;
 
     console|console_clean|console_boot)


### PR DESCRIPTION
Implemented, by moving upgrade installation from install_upgrade.escript to nodetool, which already supports both short and long names.

See https://github.com/rebar/rebar/issues/133#issuecomment-69211063 for details.

I've tested this version on my project and it works nice. No tests (`make test`) were broken.