### PR TITLE
Remove a git url in gpb and protobuffs inttest configs

### DIFF
--- a/inttest/proto_gpb/rebar.config
+++ b/inttest/proto_gpb/rebar.config
@@ -11,10 +11,8 @@
   %% The dependency below to gpb is needed for "rebar compile" to
   %% work, thus for the inttest to work, but the gpb that is actually
   %% used in inttest is brought in from the inttest/proto_gpb/mock
-  %% subdirectory, not from the source below.  The dependency is
-  %% needed, but the git url serves mostly as an example.
-  {gpb, [], {git, "git://github.com/tomas-abrahamsson/gpb",
-             {branch, "master"}}}
+  %% subdirectory.
+  {gpb, ".*"}
  ]}.
 
 {proto_compiler, gpb}.

--- a/inttest/proto_protobuffs/rebar.config
+++ b/inttest/proto_protobuffs/rebar.config
@@ -11,10 +11,8 @@
   %% The dependency below to protobuffs is needed for "rebar compile" to
   %% work, thus for the inttest to work, but the protobuffs that is actually
   %% used in inttest is brought in from the inttest/proto_protobuffs/mock
-  %% subdirectory, not from the source below.  The dependency is
-  %% needed, but the git url serves mostly as an example.
-  {protobuffs, [], {git, "git://github.com/basho/erlang_protobuffs",
-                    {branch, "master"}}}
+  %% subdirectory.
+  {protobuffs, ".*"}
  ]}.
 
 %% The default proto compiler is protobuffs


### PR DESCRIPTION
In the rebar.config files for the gpb and protobuffs inttests, use the
`{Name, Version}` dependency form instead of `{Name, Version, Source}`,
since the `Source` is not really applicable; the mocks are copied into
place by the proto_gpb_rt:files/0 and proto_protobuffs_rt:files/0.
Idea and suggestion by @tuncer.