### PR TITLE
Document recursive_cmds in -r help string as well

### DIFF
--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -488,7 +488,11 @@ option_spec_list() ->
      {keep_going, $k, "keep-going", undefined,
       "Keep running after a command fails"},
      {recursive, $r, "recursive", boolean,
-      "Apply commands to subdirs and dependencies"}
+      "Apply all commands recursively. Alternatively, you can selectively"
+      " configure what other commands in addition to the always-recursive"
+      " ones (compile, *-deps) should also be applied recursively."
+      " For example, to make 'eunit' recursive, add {recursive_cmds, [eunit]}"
+      " to rebar.config."}
     ].
 
 %%


### PR DESCRIPTION
{recursive_cmds, []} was already documented as part of the core
rebar.config options that gets printed via 'rebar -h', but this wasn't
sufficiently informative.  To fix this, explain the use of
recursive_cmds as part of the -r help string.

Reported-by: Stefan Strigler