### PR TITLE
Make rebar xref recognize -behavior()

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -133,3 +133,4 @@ Vlad Dumitrescu
 stwind
 Pavel Baturko
 Igor Savchuk
+Paulo F. Oliveira

--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -182,7 +182,8 @@ keyall(Key, List) ->
     lists:flatmap(fun({K, L}) when Key =:= K -> L; (_) -> [] end, List).
 
 get_behaviour_callbacks(exports_not_used, Attributes) ->
-    [B:behaviour_info(callbacks) || B <- keyall(behaviour, Attributes)];
+    [B:behaviour_info(callbacks) ||
+        B <- keyall(behaviour, Attributes) ++ keyall(behavior, Attributes)];
 get_behaviour_callbacks(_XrefCheck, _Attributes) ->
     [].
 


### PR DESCRIPTION
Erlang allows for -behavior as well as -behaviour (even rebar uses a mix of these) so the check should ignore the callbacks in both cases.