### PR TITLE
Fix .app.src.script bug introduced in b44b4f4

### DIFF
--- a/inttest/app_src/app_src_rt.erl
+++ b/inttest/app_src/app_src_rt.erl
@@ -1,5 +1,29 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
+%% -------------------------------------------------------------------
+%%
+%% rebar: Erlang Build Tools
+%%
+%% Copyright (c) 2014 Vlad Dumitrescu
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% -------------------------------------------------------------------
 -module(app_src_rt).
 
 -compile(export_all).
@@ -44,7 +68,7 @@ has_line([L|T], RE) ->
     end.
 
 %%
-%% Generate the contents of a simple .app.src.script file
+%% Generate the contents of a simple .app.src file
 %%
 app(Name) ->
     "{application, " ++ atom_to_list(Name) ++ ",

--- a/inttest/app_src_script_2/app_src_script_2.erl
+++ b/inttest/app_src_script_2/app_src_script_2.erl
@@ -1,0 +1,6 @@
+-module(app_src_script_2).
+
+-compile(export_all).
+
+test() ->
+    ok.

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -47,27 +47,30 @@ is_app_dir() ->
     is_app_dir(rebar_utils:get_cwd()).
 
 is_app_dir(Dir) ->
-    SrcDir = filename:join([Dir, "src"]),
-    AppSrc = filename:join([SrcDir, "*.app.{src,src.script}"]),
-    case filelib:wildcard(AppSrc) of
-        [AppSrcFile] ->
-            {true, AppSrcFile};
-        [] ->
-            EbinDir = filename:join([Dir, "ebin"]),
-            App = filename:join([EbinDir, "*.app"]),
-            case filelib:wildcard(App) of
-                [AppFile] ->
-                    {true, AppFile};
-                [] ->
-                    false;
-                _ ->
-                    ?ERROR("More than one .app file in ~s~n", [EbinDir]),
-                    false
-            end;
-        _ ->
-            ?ERROR("More than one .app.src file in ~s~n", [SrcDir]),
-            false
-    end.
+	SrcDir = filename:join([Dir, "src"]),
+	AppSrcScript = filename:join([SrcDir, "*.app.src.script"]),
+	AppSrc = filename:join([SrcDir, "*.app.src"]),
+	case {filelib:wildcard(AppSrcScript), filelib:wildcard(AppSrc)} of
+		{[AppSrcScriptFile], _} ->
+			{true, AppSrcScriptFile};
+		{[], [AppSrcFile]} ->
+			{true, AppSrcFile};
+		{[],[]} ->
+			EbinDir = filename:join([Dir, "ebin"]),
+			App = filename:join([EbinDir, "*.app"]),
+			case filelib:wildcard(App) of
+				[AppFile] ->
+					{true, AppFile};
+				[] ->
+					false;
+				_ ->
+					?ERROR("More than one .app file in ~s~n", [EbinDir]),
+					false
+			end;
+		{_, _} ->
+			?ERROR("More than one .app.src file in ~s~n", [SrcDir]),
+			false
+	end.
 
 
 is_app_src(Filename) ->


### PR DESCRIPTION
Handle the case when both .app.src and .app.src.script exist;
the script takes precedence.