### PR TITLE
Set +A0 among emulator args for rebar's escript

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,7 @@
 %% escript_incl_extra is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
 {escript_incl_extra, [{"priv/templates/*", "."}]}.
+{escript_emu_args, "%%! -pa rebar/rebar/ebin +A0\n"}.
 
 %% Types dict:dict() and digraph:digraph() have been introduced in Erlang 17.
 %% At the same time, their counterparts dict() and digraph() are to be


### PR DESCRIPTION
While switching from R15 to R16, we noticed a significant performance degradation when compiling our code with rebar (compilation time almost doubled).
Adding the "+A0" flag seems to have an extremely positive effect, reverting compile times to the R15 values.
This seems related to rebar performing lot of IO from a single process.
Not sure if the patch is general enough to be part of the upstream rebar, but I decided to open this PR to get the discussion started.
