### PR TITLE
rebar doesn't respect the order of erl_first_files given in the rebar.conf file

### DIFF
--- a/inttest/erlc/erlc_rt.erl
+++ b/inttest/erlc/erlc_rt.erl
@@ -31,7 +31,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(MODULES,
-        [first_xrl,
+        [after_first_erl,
+         first_xrl,
          first_yrl,
          first_erl,
          foo,
@@ -42,7 +43,8 @@
          'SIMPLE-ASN']).
 
 -define(BEAM_FILES,
-        ["first_xrl.beam",
+        ["after_first_erl.beam",
+         "first_xrl.beam",
          "first_yrl.beam",
          "first_erl.beam",
          "foo.beam",

--- a/inttest/erlc/extra-src/after_first_erl.erl
+++ b/inttest/erlc/extra-src/after_first_erl.erl
@@ -1,13 +1,11 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
--module(first_erl).
+-module(after_first_erl).
+-compile({parse_transform, first_erl}).
 
 -include_lib("eunit/include/eunit.hrl").
 
--export([test/0, parse_transform/2]).
+-export([test/0]).
 
 test() ->
     ?debugHere.
-
-parse_transform(Forms, _Options) ->
-    Forms.

--- a/inttest/erlc/rebar.config
+++ b/inttest/erlc/rebar.config
@@ -1,13 +1,13 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 {erl_first_files,
- ["src/first_xrl.erl", "src/first_yrl.erl", "src/first_erl.erl"]}.
+ ["src/first_xrl.erl", "src/first_yrl.erl", "src/first_erl.erl", "extra-src/after_first_erl.erl"]}.
 
 {deps, [foobar]}.
 
 {erl_opts,
  [
   {i, "extra-include"},
-  {src_dirs, ["src", "extra-src"]},
+  {src_dirs, ["extra-src", "src"]},
   {platform_define, "R13|R14", 'NO_CALLBACK_ATTRIBUTE'}
  ]}.

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -303,11 +303,11 @@ doterl_compile(Config, OutDir, MoreSources, ErlOpts) ->
     %% (rebar_config:get_local instead of rebar_config:get_list), consider
     %% logging a warning message for any file listed in erl_first_files which
     %% wasn't found via gather_src.
-    {ErlFirstFiles, RestErls} =
-        lists:partition(
-          fun(Source) ->
-                  lists:member(Source, ErlFirstFilesConf)
-          end, AllErlFiles),
+    RestErls = [File || File <- AllErlFiles,
+                        not lists:member(File, ErlFirstFilesConf)],
+    %% NOTE: order of files in ErlFirstFiles is important!
+    ErlFirstFiles = [File || File <- ErlFirstFilesConf,
+                             lists:member(File, AllErlFiles)],
     %% Make sure that ebin/ exists and is on the path
     ok = filelib:ensure_dir(filename:join("ebin", "dummy.beam")),
     CurrPath = code:get_path(),


### PR DESCRIPTION
The first commit is a fix for this issue.  The second commit is a test for this issue.  The second commit will fail if cherry-picked to the current master branch.