### PR TITLE
Generate json output from cover

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -134,3 +134,4 @@ stwind
 Pavel Baturko
 Igor Savchuk
 Mark Anderson
+Brian H. Ward

--- a/inttest/cover/cover_rt.erl
+++ b/inttest/cover/cover_rt.erl
@@ -1,0 +1,76 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+%% -------------------------------------------------------------------
+%%
+%% rebar: Erlang Build Tools
+%%
+%% Copyright (c) 2014 Brian H. Ward
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% -------------------------------------------------------------------
+-module(cover_rt).
+
+-export([files/0,run/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [{create, "ebin/foo.app", app(foo)},
+     {copy, "../../rebar","rebar"},
+     {copy, "src", "src"},
+     {copy,
+      "rebar-cover_export_json.config",
+      "rebar-cover_export_json.config"}].
+
+run(_Dir) ->
+    ifdef_test(),
+    cover_export_json_test(),
+    ok.
+
+ifdef_test() ->
+    {ok, Output} = retest:sh("./rebar -v eunit"),
+    io:format("output => ~p~n", [Output]),
+    ?assert(check_output(Output, "foo")),
+    {ok,Listing} = file:list_dir(".eunit"),
+    ?assert(check_output(Listing, "foo.beam")),
+    ?assertMatch({ok,_}, retest:sh("./rebar clean")).
+
+cover_export_json_test() ->
+    {ok,Output} =
+	retest:sh("./rebar -v -C rebar-cover_export_json.config eunit"),
+    ?assert(check_output(Output, "foo")),
+    ?assertEqual(
+       {ok, <<"{\"module\":\"foo\",\"covered\":2,\"not_covered\":1}">>},
+       file:read_file(".eunit/foo.COVER.json")),
+    ?assertMatch(
+       {ok,_},
+       retest:sh("./rebar -C rebar-cover_export_json.config clean")).
+
+check_output(Output,Target) ->
+    lists:any(fun(Line) ->
+		      string:str(Line, Target) > 0
+	      end, Output).
+app(Name) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, []},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/cover/rebar-cover_export_json.config
+++ b/inttest/cover/rebar-cover_export_json.config
@@ -1,0 +1,2 @@
+{cover_enabled, true}.
+{cover_export_json, true}.

--- a/inttest/cover/src/foo.erl
+++ b/inttest/cover/src/foo.erl
@@ -1,0 +1,18 @@
+-module(foo).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+covered_function() ->
+    "I am tested".
+
+uncovered_function() ->
+    "I am not tested".
+
+-ifdef(EUNIT).
+
+covered_function_test() ->
+    ?assertEqual("I am tested", covered_function()).
+
+-endif.


### PR DESCRIPTION
In an effort to incorporate output from cover into our automated build (CI) process, I created the ability to export the coverage information to a JSON file. This is done per-module, to simplify cross-application aggregation. added a new option
```erlang
{cover_export_json,true}.
```
which should be using in conjunction with `{cover_enabled,true}.` to produce output file(s) of the form *module_name*`.COVER.json` in the `.eunit` directory.

A retest *suite* is provided to illustrate the generation of the file(s).