### PR TITLE
Change env var delimiter to match non-word

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -133,3 +133,4 @@ Vlad Dumitrescu
 stwind
 Pavel Baturko
 Igor Savchuk
+Mark Anderson

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -254,8 +254,8 @@ expand_env_variable(InStr, VarName, RawVarValue) ->
             ReOpts = [global, unicode, {return, list}],
             VarValue = re:replace(RawVarValue, "\\\\", "\\\\\\\\", ReOpts),
             %% Use a regex to match/replace:
-            %% Given variable "FOO": match $FOO\s | $FOOeol | ${FOO}
-            RegEx = io_lib:format("\\\$(~s(\\s|$)|{~s})", [VarName, VarName]),
+            %% Given variable "FOO", match $FOO\W | $FOOeol | ${FOO}.
+            RegEx = io_lib:format("\\\$(~s(\\W|$)|{~s})", [VarName, VarName]),
             re:replace(InStr, RegEx, [VarValue, "\\2"], ReOpts)
     end.
 

--- a/test/rebar_utils_tests.erl
+++ b/test/rebar_utils_tests.erl
@@ -1,0 +1,50 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+%% -------------------------------------------------------------------
+%%
+%% rebar: Erlang Build Tools
+%%
+%% Copyright (c) 2015 Mark Anderson <mark@chef.io>
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% -------------------------------------------------------------------
+%% @author Mark Anderson <mark@chef.io>
+%% @doc Tests functionality of rebar_utils module.
+%% @copyright 2015 Mark Anderson
+%% -------------------------------------------------------------------
+-module(rebar_utils_tests).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+expand_env_variable_test_() ->
+    [{"Ensure that variable expansion handles nonwhitespace",
+      fun() ->
+              Test = "$V $V/ $Vw",
+              ?assertEqual("Val Val/ $Vw",
+                           rebar_utils:expand_env_variable(Test, "V", "Val") )
+      end},
+     {"Ensure that variable expansion with braces works",
+      fun() ->
+              Test = "${V} ${V}/ ${V}w ${Vw}",
+              ?assertEqual("Val Val/ Valw ${Vw}",
+                           rebar_utils:expand_env_variable(Test, "V", "Val") )
+      end}].
+


### PR DESCRIPTION
If I pass an expression like: "$PWD/deps/local/lib" in the port env
string, it expands to "/deps/local/lib", (variable is expanded to the
empty string) but if I pass "${PWD}/deps/local/lib" it expands
properly. I found that confusing.

This was because we require environment vars to end with whitespace,
while I think requiring a non-word character would be sufficient, since
the variables can only contain word characters.

This changes the expansion system to recognize variables that are
terminated by non word characters.

Fixes rebar/rebar#457