### PR TITLE
Remove -m64 flag.

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -607,7 +607,7 @@ default_env() ->
      %% Linux specific flags for multiarch
      {"linux.*-64$", "CFLAGS", "-m64 $CFLAGS"},
      {"linux.*-64$", "CXXFLAGS", "-m64 $CXXFLAGS"},
-     {"linux.*-64$", "LDFLAGS", "-m64 $LDFLAGS"},
+     {"linux.*-64$", "LDFLAGS", "$LDFLAGS"},
 
      %% OS X Leopard flags for 64-bit
      {"darwin9.*-64$", "CFLAGS", "-m64 $CFLAGS"},


### PR DESCRIPTION
On 64-bit Linux, remove the emulation mode flag, given -m64 is an
invalid emulation mode on 64-bit Linux.

Example compilation from Basho's erlang_js on Linux:

```
ld: unrecognised emulation mode: 64
Supported emulations: elf_x86_64 elf32_x86_64 elf_i386 i386linux elf_l1om elf_k1om i386pep i386pe
make[4]: *** [Linux_All_OPT.OBJ/libjs.so] Error 1
```