### PR TITLE
Fix error reporting crash introduced in 2e9706f

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -134,3 +134,4 @@ stwind
 Pavel Baturko
 Igor Savchuk
 Mark Anderson
+Bikram Chatterjee

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -278,7 +278,7 @@ format_error(AbsSource, Extra, {Mod, Desc}) ->
 maybe_absname(Config, Filename) ->
     case rebar_utils:processing_base_dir(Config) of
         true ->
-            Filename;
+            unit_source(Filename);
         false ->
-            filename:absname(Filename)
+            filename:absname(unit_source(Filename))
     end.


### PR DESCRIPTION
Crash:
```erlang
ERROR: compile failed while processing c:/projects/git/sqlparse: {'EXIT',{badarg,[{io,format,
                     [<0.23.0>,"Compiling ~s failed:\n",
                      [{"src/somemodule.yrl","src/somemodule.erl"}]],
                     []},
                 {rebar_base_compiler,compile_queue,3,
                                      [{file,"src/rebar_base_compiler.erl"},
                                       {line,183}]},
                 {rebar_erlc_compiler,compile,2,
                                      [{file,"src/rebar_erlc_compiler.erl"},
                                       {line,99}]},
                 {rebar_core,run_modules,4,
                             [{file,"src/rebar_core.erl"},{line,491}]},
                 {rebar_core,execute,6,
                             [{file,"src/rebar_core.erl"},{line,416}]},
                 {rebar_core,maybe_execute,8,
                             [{file,"src/rebar_core.erl"},{line,300}]},
                 {rebar_core,process_dir1,7,
                             [{file,"src/rebar_core.erl"},{line,259}]},
                 {rebar_core,process_commands,2,
                             [{file,"src/rebar_core.erl"},{line,91}]}]}}
```

After fix:
```erlang
Compiling src/somemodule.yrl failed:
```