### PR TITLE
Refactor logic and optimizations in rebar_erlc_compiler:doterl_compile/4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OTPVSNCMD='io:fwrite("~s",[rebar_utils:otp_release()]), halt().'
 OTPVSN=$(shell erl -pa ebin/ -noshell -eval $(OTPVSNCMD))
 PLT_FILENAME=~/.dialyzer_rebar_$(OTPVSN)_plt
 LOG_LEVEL?=debug
+RT_TARGETS?=inttest
 
 all:
 	./bootstrap
@@ -73,6 +74,6 @@ test_eunit: all
 	@$(REBAR) eunit
 
 test_inttest: all deps
-	@$(RETEST) -l $(LOG_LEVEL) inttest
+	@$(RETEST) -l $(LOG_LEVEL) $(RT_TARGETS)
 
 travis: clean debug xref clean all deps test

--- a/THANKS
+++ b/THANKS
@@ -135,3 +135,4 @@ Pavel Baturko
 Igor Savchuk
 Mark Anderson
 Brian H. Ward
+David Kubecka

--- a/inttest/erlc_dep_graph/erlc_dep_graph_rt.erl
+++ b/inttest/erlc_dep_graph/erlc_dep_graph_rt.erl
@@ -1,0 +1,86 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+%% -------------------------------------------------------------------
+%%
+%% rebar: Erlang Build Tools
+%%
+%% Copyright (c) 2015 David Kubecka
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% -------------------------------------------------------------------
+-module(erlc_dep_graph_rt).
+-export([files/0,
+         run/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [{copy, "../../rebar", "rebar"},
+     {copy, "src", "src"}].
+
+run(_Dir) ->
+    compile_all(ok, ""),
+    check_beams_ok(),
+    check_beams_untouched(),
+    modify_and_recompile_ok(),
+    ok.
+
+check_beams_ok() ->
+    F = fun(BeamFile) -> ?assert(filelib:is_regular(BeamFile)) end,
+    with_erl_beams(F).
+
+check_beams_untouched() ->
+    Beams = filelib:wildcard("ebin/*.beam"),
+    compile_all_and_assert_mtimes(Beams, fun erlang:'=:='/2).
+
+modify_and_recompile_ok() ->
+    touch(["src/lisp.erl"]),
+    compile_all_and_assert_mtimes(["ebin/lisp.beam"], fun erlang:'<'/2).
+
+compile_all_and_assert_mtimes(Beams, Cmp) ->
+    BeamsModifiedBefore = mtime_ns(Beams),
+    compile_all(ok, ""),
+    BeamsModifiedAfter = mtime_ns(Beams),
+    lists:zipwith(fun(Before, After) -> ?assert(Cmp(Before, After)) end,
+                  BeamsModifiedBefore, BeamsModifiedAfter).
+
+with_erl_beams(F) ->
+    lists:map(
+        fun(ErlFile) ->
+            ErlRoot = filename:rootname(filename:basename(ErlFile)),
+            BeamFile = filename:join("ebin", ErlRoot ++ ".beam"),
+            F(BeamFile)
+        end,
+        filelib:wildcard("src/*.erl")).
+
+mtime_ns(Files) ->
+    [os:cmd("stat -c%y " ++ File) || File <- Files].
+
+touch(Files) ->
+    %% Sleep one second so that filelib:last_modified/1 is guaranteed to notice
+    %% that files have changed.
+    ok = timer:sleep(1000),
+    [os:cmd("touch " ++ File) || File <- Files].
+
+compile_all(Result, Opts) ->
+    ?assertMatch({Result, _},
+        retest_sh:run("./rebar " ++ Opts ++ " compile", [])).
+
+clean_all_ok() ->
+    ?assertMatch({ok, _}, retest_sh:run("./rebar clean", [])).

--- a/inttest/erlc_dep_graph/erlc_dep_graph_rt.erl
+++ b/inttest/erlc_dep_graph/erlc_dep_graph_rt.erl
@@ -62,6 +62,9 @@ run(_Dir) ->
     %% Clean up
     ok = file:write_file(Java, OrigContent),
 
+    %% Check that changes propagate deeply through the dependency tree
+    modify_and_recompile_ok("include/lambda.hrl", "ebin/perl.beam"),
+
     ok.
 
 check_beams_ok() ->

--- a/inttest/erlc_dep_graph/erlc_dep_graph_rt.erl
+++ b/inttest/erlc_dep_graph/erlc_dep_graph_rt.erl
@@ -32,13 +32,22 @@
 
 files() ->
     [{copy, "../../rebar", "rebar"},
-     {copy, "src", "src"}].
+     {copy, "rebar.config", "rebar.config"},
+     {copy, "src", "src"},
+     {copy, "include", "include"},
+     {copy, "extra_include", "extra_include"}].
 
 run(_Dir) ->
     compile_all(ok, ""),
     check_beams_ok(),
     check_beams_untouched(),
-    modify_and_recompile_ok(),
+    modify_and_recompile_ok("src/lisp.erl", "ebin/lisp.beam"),
+
+    clean_all_ok(),
+    compile_all(error, "-C rebar.config.non-existing"),
+    compile_all(ok, ""),
+    modify_and_recompile_ok("extra_include/extra.hrl", "ebin/java.beam"),
+
     ok.
 
 check_beams_ok() ->
@@ -49,9 +58,9 @@ check_beams_untouched() ->
     Beams = filelib:wildcard("ebin/*.beam"),
     compile_all_and_assert_mtimes(Beams, fun erlang:'=:='/2).
 
-modify_and_recompile_ok() ->
-    touch(["src/lisp.erl"]),
-    compile_all_and_assert_mtimes(["ebin/lisp.beam"], fun erlang:'<'/2).
+modify_and_recompile_ok(TouchFile, CheckFile) ->
+    touch([TouchFile]),
+    compile_all_and_assert_mtimes([CheckFile], fun erlang:'<'/2).
 
 compile_all_and_assert_mtimes(Beams, Cmp) ->
     BeamsModifiedBefore = mtime_ns(Beams),

--- a/inttest/erlc_dep_graph/extra_include/extra.hrl
+++ b/inttest/erlc_dep_graph/extra_include/extra.hrl
@@ -1,0 +1,3 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+-define(CONCISE, impossible).

--- a/inttest/erlc_dep_graph/include/lambda.hrl
+++ b/inttest/erlc_dep_graph/include/lambda.hrl
@@ -1,0 +1,3 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+-define(FUN, fake).

--- a/inttest/erlc_dep_graph/rebar.config
+++ b/inttest/erlc_dep_graph/rebar.config
@@ -1,0 +1,6 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+{erl_opts,
+ [
+  {i, "extra_include"}
+ ]}.

--- a/inttest/erlc_dep_graph/src/foo.app.src
+++ b/inttest/erlc_dep_graph/src/foo.app.src
@@ -1,0 +1,7 @@
+{application,foo,
+             [{description,[]},
+              {vsn,"1.0.0"},
+              {registered,[]},
+              {applications,[kernel,stdlib]},
+              {env,[]}
+              ]}.

--- a/inttest/erlc_dep_graph/src/java.erl
+++ b/inttest/erlc_dep_graph/src/java.erl
@@ -1,0 +1,11 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+-module(java).
+
+-export([factory/0]).
+
+-include("lambda.hrl").
+-include("extra.hrl").
+
+factory() ->
+	?FUN.

--- a/inttest/erlc_dep_graph/src/java.erl.no_extra
+++ b/inttest/erlc_dep_graph/src/java.erl.no_extra
@@ -1,0 +1,10 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+-module(java).
+
+-export([factory/0]).
+
+-include("lambda.hrl").
+
+factory() ->
+	?FUN.

--- a/inttest/erlc_dep_graph/src/lisp.erl
+++ b/inttest/erlc_dep_graph/src/lisp.erl
@@ -1,0 +1,8 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+-module(lisp).
+
+-export([parse_transform/2]).
+
+parse_transform(Forms, _Options) ->
+    Forms.

--- a/inttest/erlc_dep_graph/src/lisp.erl
+++ b/inttest/erlc_dep_graph/src/lisp.erl
@@ -4,5 +4,7 @@
 
 -export([parse_transform/2]).
 
+-include("lambda.hrl").
+
 parse_transform(Forms, _Options) ->
     Forms.

--- a/inttest/erlc_dep_graph/src/lisp.erl
+++ b/inttest/erlc_dep_graph/src/lisp.erl
@@ -5,6 +5,9 @@
 -export([parse_transform/2]).
 
 -include("lambda.hrl").
+-ifdef(NOT_DEFINED).
+-include_lib("include/non/existent.hrl").
+-endif.
 
 parse_transform(Forms, _Options) ->
     Forms.

--- a/inttest/erlc_dep_graph/src/perl.erl
+++ b/inttest/erlc_dep_graph/src/perl.erl
@@ -1,0 +1,10 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+-module(perl).
+
+-export(['$_'/0]).
+
+-compile({parse_transform, lisp}).
+
+'$_'() ->
+	anything.

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -129,21 +129,10 @@ remove_common_path1([Part | RestFilename], [Part | RestPath]) ->
 remove_common_path1(FilenameParts, _) ->
     filename:join(FilenameParts).
 
-
-compile(Unit, Config, CompileFn) ->
-    case CompileFn(Unit, Config) of
-        ok ->
-            ok;
-        skipped ->
-            skipped;
-        Error ->
-            Error
-    end.
-
 compile_each([], _Config, _CompileFn) ->
     ok;
 compile_each([Unit | Rest], Config, CompileFn) ->
-    case compile(Unit, Config, CompileFn) of
+    case CompileFn(Unit, Config) of
         ok ->
             ?CONSOLE("Compiled ~s\n", [unit_source(Unit)]);
         {ok, Warnings} ->
@@ -224,7 +213,7 @@ compile_worker(QueuePid, Config, CompileFn) ->
     QueuePid ! {next, self()},
     receive
         {compile, Source} ->
-            case catch(compile(Source, Config, CompileFn)) of
+            case catch(CompileFn(Source, Config)) of
                 {ok, Ws} ->
                     QueuePid ! {compiled, Source, Ws},
                     compile_worker(QueuePid, Config, CompileFn);

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -672,14 +672,8 @@ parse_attrs(Fd, Includes) ->
     end.
 
 process_attr(Form, Includes) ->
-    try
-        AttrName = erl_syntax:atom_value(erl_syntax:attribute_name(Form)),
-        process_attr(AttrName, Form, Includes)
-    catch _:_ ->
-            %% TODO: We should probably try to be more specific here
-            %% and not suppress all errors.
-            Includes
-    end.
+    AttrName = erl_syntax:atom_value(erl_syntax:attribute_name(Form)),
+    process_attr(AttrName, Form, Includes).
 
 process_attr(import, Form, Includes) ->
     case erl_syntax_lib:analyze_import_attribute(Form) of
@@ -719,8 +713,12 @@ process_attr(compile, Form, Includes) ->
                       [atom_to_list(M) ++ ".erl"|Acc];
                  (_, Acc) ->
                       Acc
-              end, Includes, L)
-    end.
+              end, Includes, L);
+        _ ->
+            Includes
+    end;
+process_attr(_, _Form, Includes) ->
+    Includes.
 
 %% Given the filename from an include_lib attribute, if the path
 %% exists, return unmodified, or else get the absolute ERL_LIBS

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -36,7 +36,7 @@
 -include("rebar.hrl").
 -include_lib("stdlib/include/erl_compile.hrl").
 
--define(ERLCINFO_VSN, 1).
+-define(ERLCINFO_VSN, 2).
 -define(ERLCINFO_FILE, "erlcinfo").
 -type erlc_info_v() :: {digraph:vertex(), term()} | 'false'.
 -type erlc_info_e() :: {digraph:vertex(), digraph:vertex()}.

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -678,9 +678,9 @@ process_attr(Form, Includes) ->
 process_attr(import, Form, Includes) ->
     case erl_syntax_lib:analyze_import_attribute(Form) of
         {Mod, _Funs} ->
-            [atom_to_list(Mod) ++ ".erl"|Includes];
+            [module_to_erl(Mod)|Includes];
         Mod ->
-            [atom_to_list(Mod) ++ ".erl"|Includes]
+            [module_to_erl(Mod)|Includes]
     end;
 process_attr(file, Form, Includes) ->
     {File, _} = erl_syntax_lib:analyze_file_attribute(Form),
@@ -696,21 +696,21 @@ process_attr(include_lib, Form, Includes) ->
     [File|Includes];
 process_attr(behaviour, Form, Includes) ->
     [FileNode] = erl_syntax:attribute_arguments(Form),
-    File = erl_syntax:atom_name(FileNode) ++ ".erl",
+    File = module_to_erl(erl_syntax:atom_value(FileNode)),
     [File|Includes];
 process_attr(compile, Form, Includes) ->
     [Arg] = erl_syntax:attribute_arguments(Form),
     case erl_syntax:concrete(Arg) of
         {parse_transform, Mod} ->
-            [atom_to_list(Mod) ++ ".erl"|Includes];
+            [module_to_erl(Mod)|Includes];
         {core_transform, Mod} ->
-            [atom_to_list(Mod) ++ ".erl"|Includes];
+            [module_to_erl(Mod)|Includes];
         L when is_list(L) ->
             lists:foldl(
-              fun({parse_transform, M}, Acc) ->
-                      [atom_to_list(M) ++ ".erl"|Acc];
-                 ({core_transform, M}, Acc) ->
-                      [atom_to_list(M) ++ ".erl"|Acc];
+              fun({parse_transform, Mod}, Acc) ->
+                      [module_to_erl(Mod)|Acc];
+                 ({core_transform, Mod}, Acc) ->
+                      [module_to_erl(Mod)|Acc];
                  (_, Acc) ->
                       Acc
               end, Includes, L);
@@ -719,6 +719,9 @@ process_attr(compile, Form, Includes) ->
     end;
 process_attr(_, _Form, Includes) ->
     Includes.
+
+module_to_erl(Mod) ->
+    atom_to_list(Mod) ++ ".erl".
 
 %% Given the filename from an include_lib attribute, if the path
 %% exists, return unmodified, or else get the absolute ERL_LIBS

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -485,7 +485,7 @@ store_erlcinfo(G, InclDirs) ->
     Es = lists:map(fun(E) -> digraph:edge(G, E) end, digraph:edges(G)),
     File = erlcinfo_file(),
     ok = filelib:ensure_dir(File),
-    Data = term_to_binary(#erlcinfo{info={Vs, Es, InclDirs}}, [{compressed, 9}]),
+    Data = term_to_binary(#erlcinfo{info={Vs, Es, InclDirs}}, [{compressed, 2}]),
     ok = file:write_file(File, Data).
 
 %% NOTE: If, for example, one of the entries in Files refers to

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -448,6 +448,7 @@ modify_erlcinfo(G, Source, Dirs) ->
     ok = file:close(Fd),
     LastUpdated = {date(), time()},
     digraph:add_vertex(G, Source, LastUpdated),
+    digraph:del_edges(G, digraph:out_edges(G, Source)),
     lists:foreach(
       fun(Incl) ->
               update_erlcinfo(G, Dirs, Incl),

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -327,6 +327,9 @@ needed_files(G, OutDir, SourceFiles) ->
         digraph:vertex(G, Source) > {Source, filelib:last_modified(Target)}
     end, SourceFiles).
 
+target_base(OutDir, Source) ->
+    filename:join(OutDir, filename:basename(Source, ".erl")).
+
 erlcinfo_file() ->
     filename:join([rebar_utils:get_cwd(), ".rebar", ?ERLCINFO_FILE]).
 
@@ -468,9 +471,8 @@ expand_file_names(Files, Dirs) ->
 -spec internal_erl_compile(rebar_config:config(), file:filename(),
     file:filename(), list()) -> ok | {ok, any()} | {error, any(), any()}.
 internal_erl_compile(Config, Source, OutDir, ErlOpts) ->
-    TargetDir = filename:dirname(target_base(OutDir, Source)),
-    ok = filelib:ensure_dir(TargetDir),
-    Opts = [{outdir, TargetDir}] ++ ErlOpts ++ [{i, "include"}, return],
+    ok = filelib:ensure_dir(OutDir),
+    Opts = [{outdir, OutDir}] ++ ErlOpts ++ [{i, "include"}, return],
     case compile:file(Source, Opts) of
         {ok, _Mod} ->
             ok;
@@ -479,10 +481,6 @@ internal_erl_compile(Config, Source, OutDir, ErlOpts) ->
         {error, Es, Ws} ->
             rebar_base_compiler:error_tuple(Config, Source, Es, Ws, Opts)
     end.
-
-target_base(OutDir, Source) ->
-    Module = filename:basename(Source, ".erl"),
-    filename:join([OutDir|string:tokens(Module, ".")]).
 
 -spec compile_mib(file:filename(), file:filename(),
                   rebar_config:config()) -> 'ok'.


### PR DESCRIPTION
- Change format of erlcinfo so that it is more robust and contains enough info for deciding which files need to be recompiled.
- Add tests.
- Remove unneeded code.