### PR TITLE
Add options 'groups' and 'cases' to 'ct' command

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -135,3 +135,4 @@ Pavel Baturko
 Igor Savchuk
 Mark Anderson
 Brian H. Ward
+Danil Onishchenko

--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -450,7 +450,7 @@ eunit       [suite[s]=foo]               Run EUnit tests in foo.erl and
             [random_suite_order=Seed]    with a random seed for the PRNG, or a
                                          specific one.
 
-ct          [suite[s]=] [case=]          Run common_test suites
+ct          [suite[s]= [group[s]= [case[s]=]]] Run common_test suites
 
 qc                                       Test QuickCheck properties
 


### PR DESCRIPTION
* Add an option `groups` to `rebar ct` command. So the command 
`rebar ct suites=Suite1 groups=Group1,Group2,...,GroupN`
is equal to 
`ct_run -suite Suite1_SUITE -group Group1 Group2 ... GroupN` 
It allows to run specified test groups in specified test suite with Common Test tool. Besides it is absolutely necessary to specify groups for running test cases which are included in these groups, otherwise `init_per_group/2` and `end_per_group/1` callbacks are not called by `ct_run`.

* Add an option `cases` to `rebar ct` command. So the command 
`rebar ct suites=Suite1 cases=Case1,Case2,...,CaseN` 
is equal to 
`ct_run -suite Suite1_SUITE -case Case1 Case2 ... CaseN` 
It allows to run one or more test cases in specified test suite. Currently `rebar` has an option `case` which allows to run only one test case. The option `case` is remained for backward compability. It's suggested to consider the option `case` as deprecated and is recommended to use `cases` instead.

* Update help messages according to new command line options.