### PR TITLE
Enable parse transformations in rebar config

### DIFF
--- a/inttest/erlc_dep_graph/src/pascal.erl
+++ b/inttest/erlc_dep_graph/src/pascal.erl
@@ -1,8 +1,8 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-{erl_opts,
- [
-  {i, "extra_include"},
-  {parse_transform, lisp},
-  {parse_transform, pascal}
- ]}.
+-module(pascal).
+
+-export([parse_transform/2]).
+
+parse_transform(Forms, _Options) ->
+    Forms.


### PR DESCRIPTION
Only thing which is neccesary is to ensure that parse
transformations are not applied to themselves and probably
also to erl_first_files since they are explicitly stated as
to be compiled before anything else.