### PR TITLE
Windows runner - CD to node root

### DIFF
--- a/priv/templates/simplenode.windows.runner.cmd
+++ b/priv/templates/simplenode.windows.runner.cmd
@@ -6,6 +6,9 @@
 @rem which is assumed to be the node root.
 @for /F "delims=" %%I in ("%~dp0..") do @set node_root=%%~fI
 
+@rem CWD to the node root directory
+@cd %node_root%
+
 @set releases_dir=%node_root%\releases
 
 @rem Parse ERTS version and release version from start_erl.data


### PR DESCRIPTION
Changes to the Windows runner to CD to the node root directory.

This prevents stuff like lager logging going into the current "log" directory instead of the node release "log" directory.

The unix runner already runs from the node root.