### PR TITLE
Fix crash on failed build console output

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -173,10 +173,10 @@ compile_queue(Config, Pids, Targets) ->
                     compile_queue(Config, Pids, Rest)
             end;
 
-        {fail, {_, {source, Source}}=Error} ->
+        {fail, {_, {source, Unit}}=Error} ->
             maybe_report(Error),
             ?CONSOLE("Compiling ~s failed:\n",
-                     [maybe_absname(Config, Source)]),
+                     [unit_source(Unit)]),
             ?DEBUG("Worker compilation failed: ~p\n", [Error]),
             case rebar_config:get_xconf(Config, keep_going, false) of
                 false ->


### PR DESCRIPTION
Fixes console output crash on failed build of github.com:lfex/yaws-rest-starter.git.
Build fail case clause was treating the source as a compile unit which is actually a tuple containing the source and the target

> ERROR: compile failed while processing
> /home/holly/projects/yaws-rest-starter: {'EXIT',{badarg,[{io,format,
>                      [<0.24.0>,"Compiling ~s failed:\n",
>
> [{"src/yrests-store-2.lfe","ebin/yrests-store-2.beam"}]],
>                      []},
>                  {rebar_base_compiler,compile_queue,3,
>                                       [{file,"src/rebar_base_compiler.erl"},
>                                        {line,178}]},
>                  {rebar_core,run_modules,4,
>                              [{file,"src/rebar_core.erl"},{line,493}]},
>                  {rebar_core,execute,6,
>                              [{file,"src/rebar_core.erl"},{line,418}]},
>                  {rebar_core,maybe_execute,8,
>                              [{file,"src/rebar_core.erl"},{line,302}]},
>                  {rebar_core,process_dir1,7,
>                              [{file,"src/rebar_core.erl"},{line,261}]},
>                  {rebar_core,process_commands,2,
>                              [{file,"src/rebar_core.erl"},{line,93}]},
>                  {rebar,main,1,[{file,"src/rebar.erl"},{line,58}]}]}}