### PR TITLE
fix absolute source path on failed build, add gpb proto error test case

### DIFF
--- a/inttest/proto_gpb/mock/gpb/src/gpb_compile.erl
+++ b/inttest/proto_gpb/mock/gpb/src/gpb_compile.erl
@@ -29,7 +29,12 @@
 
 %% Simulate gpb compiling some proto files,
 %% but generate only enough of what's needed for testing -- dummy stuff only.
+%% if a bad.proto file is supplied then gpb fails
 file(Proto, Opts) ->
+    ok = case filename:basename(Proto) of
+            "bad.proto" -> error;
+            _ -> ok
+         end,
     Prefix = proplists:get_value(module_name_prefix, Opts, ""),
     Suffix = proplists:get_value(module_name_suffix, Opts, ""),
     ProtoBase = filename:basename(Proto, ".proto"),

--- a/inttest/proto_gpb/proto.bad/a/b/test3.proto
+++ b/inttest/proto_gpb/proto.bad/a/b/test3.proto
@@ -1,0 +1,19 @@
+// -*- c-basic-offset: 4; indent-tabs-mode: nil -*-
+// ex: ts=4 sw=4 et
+
+package test3;
+
+service test3
+{
+    rpc testRpc3(RPC_INPUT3) returns (RPC_OUTPUT3);
+}
+
+message RPC_INPUT3
+{
+    optional string str = 1;
+}
+
+message RPC_OUTPUT3
+{
+    optional string str = 1;
+}

--- a/inttest/proto_gpb/proto.bad/a/test2.proto
+++ b/inttest/proto_gpb/proto.bad/a/test2.proto
@@ -1,0 +1,19 @@
+// -*- c-basic-offset: 4; indent-tabs-mode: nil -*-
+// ex: ts=4 sw=4 et
+
+package test2;
+
+service test2
+{
+    rpc testRpc2(RPC_INPUT2) returns (RPC_OUTPUT2);
+}
+
+message RPC_INPUT2
+{
+    optional string str = 1;
+}
+
+message RPC_OUTPUT2
+{
+    optional string str = 1;
+}

--- a/inttest/proto_gpb/proto.bad/bad.proto
+++ b/inttest/proto_gpb/proto.bad/bad.proto
@@ -1,0 +1,19 @@
+// -*- c-basic-offset: 4; indent-tabs-mode: nil -*-
+// ex: ts=4 sw=4 et
+
+package test;
+
+service test
+{
+    rpc testRpc(RPC_INPUT) returns (RPC_OUTPUT);
+}
+
+message RPC_INPUT
+    // bug introduced intentionally here
+    optional string str = 1;
+}
+
+message RPC_OUTPUT
+{
+    optional string str = 1;
+}

--- a/inttest/proto_gpb/proto.bad/c/d/test5.proto
+++ b/inttest/proto_gpb/proto.bad/c/d/test5.proto
@@ -1,0 +1,19 @@
+// -*- c-basic-offset: 4; indent-tabs-mode: nil -*-
+// ex: ts=4 sw=4 et
+
+package test5;
+
+service test5
+{
+    rpc testRpc5(RPC_INPUT5) returns (RPC_OUTPUT5);
+}
+
+message RPC_INPUT5
+{
+    optional string str = 1;
+}
+
+message RPC_OUTPUT5
+{
+    optional string str = 1;
+}

--- a/inttest/proto_gpb/proto.bad/c/test4.proto
+++ b/inttest/proto_gpb/proto.bad/c/test4.proto
@@ -1,0 +1,19 @@
+// -*- c-basic-offset: 4; indent-tabs-mode: nil -*-
+// ex: ts=4 sw=4 et
+
+package test4;
+
+service test4
+{
+    rpc testRpc4(RPC_INPUT4) returns (RPC_OUTPUT4);
+}
+
+message RPC_INPUT4
+{
+    optional string str = 1;
+}
+
+message RPC_OUTPUT4
+{
+    optional string str = 1;
+}

--- a/inttest/proto_gpb/proto.bad/test.proto
+++ b/inttest/proto_gpb/proto.bad/test.proto
@@ -1,0 +1,19 @@
+// -*- c-basic-offset: 4; indent-tabs-mode: nil -*-
+// ex: ts=4 sw=4 et
+
+package test;
+
+service test
+{
+    rpc testRpc(RPC_INPUT) returns (RPC_OUTPUT);
+}
+
+message RPC_INPUT
+{
+    optional string str = 1;
+}
+
+message RPC_OUTPUT
+{
+    optional string str = 1;
+}

--- a/inttest/proto_gpb/proto_gpb_rt.erl
+++ b/inttest/proto_gpb/proto_gpb_rt.erl
@@ -56,20 +56,35 @@ files() ->
      {copy, "../../rebar", "rebar"},
      {copy, "rebar.config", "rebar.config"},
      {copy, "rebar2.config", "rebar2.config"},
+     {copy, "rebar.bad.config", "rebar.bad.config"},
      {copy, "include", "include"},
      {copy, "src", "src"},
      {copy, "proto", "proto"},
+     {copy, "proto.bad", "proto.bad"},
      {copy, "mock", "deps"},
      {create, "ebin/foo.app", app(foo, ?MODULES ++ ?GENERATED_MODULES)}
     ].
 
 run(_Dir) ->
     % perform test obtaining the .proto files from src dir
-    ok = run_from_dir("src", "rebar.config"),
+    ok = run_from_dir(success_expected, "src", "rebar.config"),
     % perform test obtaining the .proto files from proto dir
-    ok = run_from_dir("proto", "rebar2.config").
+    ok = run_from_dir(success_expected, "proto", "rebar2.config"),
+    % perform a test where a failure is expected
+    ok = run_from_dir(fail_expected, "proto.bad", "rebar.bad.config").
 
-run_from_dir(ProtoDir, ConfigFile) ->
+run_from_dir(fail_expected, _ProtoDir, ConfigFile) ->
+    %% we expect a fail to happen, however rebar should not crash
+    %% we make sure of that by scanning the error
+    {error, {stopped, {1, Error}}} = retest_sh:run("./rebar --config "
+                                                   ++ ConfigFile
+                                                   ++ " compile",
+                                                   []),
+    %% no matches of the string 'EXIT' should occur, these
+    %% indicate a rebar crash and not a exit with error
+    0 = string:str(lists:flatten(Error), "'EXIT'"),
+    ok;
+run_from_dir(success_expected, ProtoDir, ConfigFile) ->
     ?assertMatch({ok, _}, retest_sh:run("./rebar --config "
                                         ++ ConfigFile
                                         ++ " clean",

--- a/inttest/proto_gpb/rebar.bad.config
+++ b/inttest/proto_gpb/rebar.bad.config
@@ -1,0 +1,23 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+
+{erl_opts,
+ [
+  {platform_define, "R13|R14", 'NO_CALLBACK_ATTRIBUTE'}
+ ]}.
+
+{deps,
+ [
+  %% The dependency below to gpb is needed for "rebar compile" to
+  %% work, thus for the inttest to work, but the gpb that is actually
+  %% used in inttest is brought in from the inttest/proto_gpb/mock
+  %% subdirectory.
+  {gpb, ".*"}
+ ]}.
+
+{proto_opts, [
+    {compiler, gpb},
+    {src_dirs, ["proto.bad"]}
+]}.
+
+{gpb_opts, [{module_name_suffix, "_gpb"}]}.

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -176,7 +176,7 @@ compile_queue(Config, Pids, Targets) ->
         {fail, {_, {source, Unit}}=Error} ->
             maybe_report(Error),
             ?CONSOLE("Compiling ~s failed:\n",
-                     [unit_source(Unit)]),
+                     [maybe_absname(Config, unit_source(Unit))]),
             ?DEBUG("Worker compilation failed: ~p\n", [Error]),
             case rebar_config:get_xconf(Config, keep_going, false) of
                 false ->


### PR DESCRIPTION
Fixes regression introduced in fix PR #489 regarding console output of absolute source paths, expands proto_gpb test case to add coverage for said regression 