### PR TITLE
Update line number of allowed dialyzer error

### DIFF
--- a/dialyzer_reference
+++ b/dialyzer_reference
@@ -1,3 +1,3 @@
 
 rebar_eunit.erl:471: Call to missing or unexported function eunit_test:function_wrapper/2
-rebar_utils.erl:198: Call to missing or unexported function escript:foldl/3
+rebar_utils.erl:222: Call to missing or unexported function escript:foldl/3


### PR DESCRIPTION
Running `make check` after `make debug` gives an error due to the
following:

```
make: [dialyzer_warnings] Error 2 (ignored)
--- dialyzer_reference  2015-05-11 17:21:38.000000000 -0400
+++ dialyzer_warnings   2015-05-11 17:31:42.000000000 -0400
@@ -3 +3 @@
-rebar_utils.erl:198: Call to missing or unexported function
escript:foldl/3
+rebar_utils.erl:222: Call to missing or unexported function
escript:foldl/3
```

Indeed that call to `escript:foldl/3` changed from line 198 to 222 via
https://github.com/rebar/rebar/commit/a04530124ffa16c50205695d35f9274107e2fa42

This update makes the corresponding change to the line number in
dialyzer_reference.

This was noticed while working on
https://github.com/rebar/rebar/pull/336