### PR TITLE
Handle all Windows OS types

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -139,7 +139,7 @@ setup_env(Config) ->
     {true, DepsDir} = get_deps_dir(Config),
     %% include rebar's DepsDir in ERL_LIBS
     Separator = case os:type() of
-                    {win32, nt} ->
+                    {win32, _} ->
                         ";";
                     _ ->
                         ":"

--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -365,7 +365,7 @@ port_opt(Config, {env, Env}) ->
 port_opt(_Config, Opt) ->
     Opt.
 
-maybe_switch_extension({win32, nt}, Target) ->
+maybe_switch_extension({win32, _}, Target) ->
     switch_to_dll_or_exe(Target);
 maybe_switch_extension(_OsType, Target) ->
     Target.

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -333,7 +333,7 @@ delayed_halt(Code) ->
             halt(Code);
         false ->
             case os:type() of
-                {win32, nt} ->
+                {win32, _} ->
                     timer:sleep(100),
                     halt(Code);
                 _ ->
@@ -464,7 +464,7 @@ get_experimental_3(Get, Config, Opt, Default) ->
 %% command doesn't use any other shell magic.
 patch_on_windows(Cmd, Env) ->
     case os:type() of
-        {win32,nt} ->
+        {win32, _} ->
             Cmd1 = "cmd /q /c "
                 ++ lists:foldl(fun({Key, Value}, Acc) ->
                                        expand_env_variable(Acc, Key, Value)


### PR DESCRIPTION
Avoid matching Osname to work better with Windows 95.

From Erlang/OTP os reference manual:

  os:type() -> {Osfamily, Osname}

  [...]

  In Windows, Osname will be either nt (on Windows NT), or windows (on
  Windows 95). [...] Avoid matching on the Osname atom.

No tests added as I guess the best way to test this is to run all tests on Windows 95.