### PR TITLE
Try one more location for the OTP_VERSION file

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -140,3 +140,4 @@ Carlos Eduardo de Paula
 Paulo F. Oliveira
 Derek Brown
 Danil Onishchenko
+Stavros Aronis

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -413,8 +413,14 @@ otp_release1([$R,N|_]=Rel) when is_integer(N) ->
 %% the "\n".
 otp_release1(Rel) ->
     File = filename:join([code:root_dir(), "releases", Rel, "OTP_VERSION"]),
-    {ok, Vsn} = file:read_file(File),
-
+    Vsn = case file:read_file(File) of
+              {ok, V} -> V;
+              {error, enoent} ->
+                  FileNotInstalled = filename:join([code:root_dir(),
+                                                    "OTP_VERSION"]),
+                  {ok, V} = file:read_file(FileNotInstalled),
+                  V
+          end,
     %% It's fine to rely on the binary module here because we can
     %% be sure that it's available when the otp_release string does
     %% not begin with $R.


### PR DESCRIPTION
If one is building Erlang from sources without making a proper release, there
may be an OTP_VERSION file in the root directory.