### PR TITLE
Drop `shared` PLTs support and change PLT name to <OTP-VSN>.plt

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -141,3 +141,4 @@ Paulo F. Oliveira
 Derek Brown
 Danil Onishchenko
 Stavros Aronis
+James Fish

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -271,9 +271,7 @@
 
 {dialyzer,
  [
-  %% Store PLT in ~/.rebar/plt (Default)
-  {plt_location, shared},
-  %% Store PLT locally inside the project in .rebar
+  %% Store PLT locally inside the project in .rebar (Default)
   {plt_location, local},
   %% Store PLT in custom directory
   {plt_location, "custom_dir"},

--- a/src/rebar_dialyzer.erl
+++ b/src/rebar_dialyzer.erl
@@ -144,7 +144,6 @@ info_help(Description) ->
         {dialyzer,
          [
           {plt_location, local},
-          {plt_location, shared},
           {plt_location, "custom_dir"},
           {plt_extra_apps, [app1, app2]},
           {warnings, [unmatched_returns, error_handling]}
@@ -176,10 +175,7 @@ plt_dir1(_Config, Location) when is_list(Location) ->
     end;
 plt_dir1(Config, local) ->
     BaseDir = rebar_utils:base_dir(Config),
-    filename:join([BaseDir, ".rebar"]);
-plt_dir1(_Config, shared) ->
-    {ok, Home} = init:get_argument(home),
-    filename:join([Home, ".rebar", "plt"]).
+    filename:join([BaseDir, ".rebar"]).
 
 check_plt_existence(Plt) ->
     case filelib:is_regular(Plt) of


### PR DESCRIPTION
I am worried about supporting the `shared` PLT location option because it will be very easy to use a PLT which is not suitable or has slightly different files than a project's dependencies. If there are two branches of an application with different versions of dependencies the same PLT probably should not be used.

I think it would be better to require a user to be specific about how they are sharing PLTs using the explicit directory location. Otherwise someone unfamiliar with dialyzer might think `shared` is an optimisation and end up using dialyzer incorrectly or in a sub-optimal fashion. That is, we should definitely make the optimisation available for those who need it (with the directory name option) but we should not make it too easy to do the wrong thing.

I also took this opportunity to change to the default PLT name to match that used (currently) by rebar3. It is very awkward to include the application name in the PLT's name because there can be multiple applications in a rebar3 release project. Without the `shared` option the PLT does not need to include the application name.