### PR TITLE
Fix 'make deps'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ binary: clean all
 	(cd ../rebar.wiki && git commit -m "Update $(VSN)" rebar)
 
 deps:
-	@REBAR_EXTRA_DEPS=1 ./rebar get-deps
-	$(MAKE) -C deps/retest
+	@REBAR_EXTRA_DEPS=1 $(REBAR) get-deps
+	@(cd deps/retest && $(REBAR) compile escriptize)
 
 test: test_eunit test_inttest
 


### PR DESCRIPTION
We have to partially revert f3f8f29. The reason for not running
"make -C deps/retest" is to avoid a dependency on rebar in $PATH.

While at it, change one ./rebar to $(REBAR).