### PR TITLE
Generate reserved file for erlc regression test

### DIFF
--- a/inttest/erlc/erlc_rt.erl
+++ b/inttest/erlc/erlc_rt.erl
@@ -66,6 +66,10 @@ files() ->
      {copy, "mibs", "mibs"},
      {copy, "asn1", "asn1"},
      {create, "ebin/foo.app", app(foo, ?MODULES)},
+     {create, "src/._do_not_compile.erl",
+              "syntax error\n"
+              "this file is here to verify that rebar does not try to compile\n"
+              "files like OS X resource forks and should not be processed at all\n"},
      %% deps
      {create, "deps/foobar/ebin/foobar.app", app(foobar, [foobar])},
      {copy, "foobar.erl", "deps/foobar/src/foobar.erl"}

--- a/inttest/erlc/src/._do_not_compile.erl
+++ b/inttest/erlc/src/._do_not_compile.erl
@@ -1,4 +1,0 @@
-syntax error
-this file is here to verify that rebar does not try to
-compile files like OS X resource forks and should not be
-processed at all


### PR DESCRIPTION
Reserved files such as ._do_not_compile.erl should be
generated automatically when running the regression
test and not added to the repo. .tar.gz source releases
are not correctly generated when handling such files.