### PR TITLE
Fixed version of #451

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -142,3 +142,4 @@ Derek Brown
 Danil Onishchenko
 Stavros Aronis
 James Fish
+Tony Rogvall

--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,8 @@
       - (\"gpb_compile\":\"format_error\"/\"1\")
       - (\"diameter_codegen\":\"from_dict\"/\"4\")
       - (\"diameter_dict_util\":\"format_error\"/\"1\")
-      - (\"diameter_dict_util\":\"parse\"/\"2\"))",
+      - (\"diameter_dict_util\":\"parse\"/\"2\")
+      - (\"erlang\":\"timestamp\"/\"0\"))",
          []}]}.
 
 {dialyzer,

--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -568,8 +568,8 @@ erl_interface_dir(Subdir) ->
     end.
 
 default_env() ->
-    Arch = os:getenv("REBAR_ARCH_TARGET"),
-    Vsn = os:getenv("REBAR_ARCH_TARGET_VSN"),
+    Arch = os:getenv("REBAR_TARGET_ARCH"),
+    Vsn = os:getenv("REBAR_TARGET_ARCH_VSN"),
     [
      {"CC" , get_tool(Arch,Vsn,"gcc","cc")},
      {"CXX", get_tool(Arch,Vsn,"g++","c++")},

--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -568,9 +568,21 @@ erl_interface_dir(Subdir) ->
     end.
 
 default_env() ->
+    Arch = os:getenv("REBAR_ARCH_TARGET"),
+    Vsn = os:getenv("REBAR_ARCH_TARGET_VSN"),
     [
-     {"CC" , "cc"},
-     {"CXX", "c++"},
+     {"CC" , get_tool(Arch,Vsn,"gcc","cc")},
+     {"CXX", get_tool(Arch,Vsn,"g++","c++")},
+     {"AR" , get_tool(Arch,"ar","ar")},
+     {"AS" , get_tool(Arch,"as","as")},
+     {"CPP" , get_tool(Arch,Vsn,"cpp","cpp")},
+     {"LD" , get_tool(Arch,"ld","ld")},
+     {"RANLIB" , get_tool(Arch,Vsn,"ranlib","ranlib")},
+     {"STRIP" , get_tool(Arch,"strip","strip")},
+     {"NM" , get_tool(Arch,"nm","nm")},
+     {"OBJCOPY" , get_tool(Arch,"objcopy","objcopy")},
+     {"OBJDUMP" , get_tool(Arch,"objdump","objdump")},
+
      {"DRV_CXX_TEMPLATE",
       "$CXX -c $CXXFLAGS $DRV_CFLAGS $PORT_IN_FILES -o $PORT_OUT_FILE"},
      {"DRV_CC_TEMPLATE",
@@ -643,3 +655,16 @@ default_env() ->
      {"win32", "DRV_CFLAGS", "/Zi /Wall $ERL_CFLAGS"},
      {"win32", "DRV_LDFLAGS", "/DLL $ERL_LDFLAGS"}
     ].
+
+get_tool(Arch,Tool,Default) ->
+    get_tool(Arch,false,Tool,Default).
+
+get_tool(false, _, _, Default) -> Default;
+get_tool("",_,_, Default) -> Default;
+get_tool(Arch, false, Tool, _Default) -> Arch++"-"++Tool;
+get_tool(Arch, "", Tool, _Default) -> Arch++"-"++Tool;
+get_tool(Arch, Vsn, Tool, _Default) -> Arch++"-"++Tool++"-"++Vsn.
+
+
+
+    

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -98,13 +98,13 @@ is_arch(ArchRegex) ->
             false
     end.
 %%
-%% REBAR_ARCH_TARGET, if used, should be set to the "standard" 
+%% REBAR_TARGET_ARCH, if used, should be set to the "standard" 
 %% target string. That is a prefix for binutils tools.
 %% "x86_64-linux-gnu" or "arm-linux-gnueabi" are good candiates
-%% ${REBAR_ARCH_TARGET}-gcc, ${REBAR_ARCH_TARGET}-ld ...
+%% ${REBAR_TARGET_ARCH}-gcc, ${REBAR_TARGET_ARCH}-ld ...
 %%
 get_arch() ->
-    Arch = os:getenv("REBAR_ARCH_TARGET"),
+    Arch = os:getenv("REBAR_TARGET_ARCH"),
     Words = wordsize(Arch),
     otp_release() ++ "-" ++ get_system_arch(Arch) ++ "-" ++ Words.
 
@@ -114,17 +114,18 @@ get_system_arch(Arch) ->
     Arch.
 
 wordsize() ->
-    wordsize(os:getenv("REBAR_ARCH_TARGET")).
+    wordsize(os:getenv("REBAR_TARGET_ARCH")).
 
 wordsize(Arch) when Arch =:= false; Arch =:= "" ->
     native_wordsize();
 wordsize(Arch) ->
     case match_wordsize(Arch, [{"i686","32"}, {"i386","32"},
-                               {"arm","32"}, {"x86_64","64"}]) of
+                               {"arm","32"}, {"aarch64", "64"},
+                               {"x86_64","64"}]) of
         false ->
             case cross_wordsize(Arch) of
                 "" ->
-                    env_wordsize(os:getenv("REBAR_ARCH_WORDSIZE"));
+                    env_wordsize(os:getenv("REBAR_TARGET_ARCH_WORDSIZE"));
                 WordSize -> WordSize
             end;
         {_, Wordsize} ->
@@ -140,7 +141,7 @@ match_wordsize(Arch, [V={Match,_Bits}|Vs]) ->
 
 env_wordsize(Wordsize) when Wordsize =:= false;
                             Wordsize =:= "" ->
-    io:format("REBAR_ARCH_WORDSIZE not set, assuming 32\n"),
+    io:format("REBAR_TARGET_ARCH_WORDSIZE not set, assuming 32\n"),
     "32";
 env_wordsize(Wordsize) ->
     try list_to_integer(Wordsize) of
@@ -148,11 +149,11 @@ env_wordsize(Wordsize) ->
         32 -> "32";
         64 -> "64";
         _ ->
-            io:format("REBAR_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
+            io:format("REBAR_TARGET_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
             "32"
     catch
         error:_ ->
-            io:format("REBAR_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
+            io:format("REBAR_TARGET_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
             "32"
     end.
 

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -67,12 +67,7 @@
          processing_base_dir/1,
          processing_base_dir/2,
          patch_env/2,
-         cleanup_code_path/1,
-         cross_wordsize/1,
-         native_wordsize/0,
-         wordsize/1,
-         cross_sizeof/2,
-         env_wordsize/1
+         cleanup_code_path/1
         ]).
 
 %% for internal use only
@@ -98,9 +93,9 @@ is_arch(ArchRegex) ->
             false
     end.
 %%
-%% REBAR_TARGET_ARCH, if used, should be set to the "standard" 
+%% REBAR_TARGET_ARCH, if used, should be set to the "standard"
 %% target string. That is a prefix for binutils tools.
-%% "x86_64-linux-gnu" or "arm-linux-gnueabi" are good candiates
+%% "x86_64-linux-gnu" or "arm-linux-gnueabi" are good candidates
 %% ${REBAR_TARGET_ARCH}-gcc, ${REBAR_TARGET_ARCH}-ld ...
 %%
 get_arch() ->
@@ -115,117 +110,6 @@ get_system_arch(Arch) ->
 
 wordsize() ->
     wordsize(os:getenv("REBAR_TARGET_ARCH")).
-
-wordsize(Arch) when Arch =:= false; Arch =:= "" ->
-    native_wordsize();
-wordsize(Arch) ->
-    case match_wordsize(Arch, [{"i686","32"}, {"i386","32"},
-                               {"arm","32"}, {"aarch64", "64"},
-                               {"x86_64","64"}]) of
-        false ->
-            case cross_wordsize(Arch) of
-                "" ->
-                    env_wordsize(os:getenv("REBAR_TARGET_ARCH_WORDSIZE"));
-                WordSize -> WordSize
-            end;
-        {_, Wordsize} ->
-            Wordsize
-    end.
-
-match_wordsize(Arch, [V={Match,_Bits}|Vs]) ->
-    case re:run(Arch, Match, [{capture, none}]) of
-        match -> V;
-        _ ->
-            match_wordsize(Arch, Vs)
-    end.
-
-env_wordsize(Wordsize) when Wordsize =:= false;
-                            Wordsize =:= "" ->
-    io:format("REBAR_TARGET_ARCH_WORDSIZE not set, assuming 32\n"),
-    "32";
-env_wordsize(Wordsize) ->
-    try list_to_integer(Wordsize) of
-        16 -> "16";
-        32 -> "32";
-        64 -> "64";
-        _ ->
-            io:format("REBAR_TARGET_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
-            "32"
-    catch
-        error:_ ->
-            io:format("REBAR_TARGET_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
-            "32"
-    end.
-
-%%
-%% Findout the word size of the target by using Arch-gcc
-%%
-
-cross_wordsize(Arch) ->
-    cross_sizeof(Arch, "void*").
-
-%%
-%% Find the size of target Type using a specially crafted C file 
-%% that will report an error on the line of the byte size of the type.
-%% 
-                       
-cross_sizeof(Arch, Type) ->
-    Compiler = if  Arch =:= "" -> "cc";
-                   true -> Arch ++ "-gcc"
-               end,
-    TempFile = mktemp(".c"),
-    file:write_file(TempFile,
-                    <<"int t01 [1 - 2*(((long) (sizeof (TYPE))) == 1)];\n"
-                      "int t02 [1 - 2*(((long) (sizeof (TYPE))) == 2)];\n"
-                      "int t03 [1 - 2*(((long) (sizeof (TYPE))) == 3)];\n"
-                      "int t04 [1 - 2*(((long) (sizeof (TYPE))) == 4)];\n"
-                      "int t05 [1 - 2*(((long) (sizeof (TYPE))) == 5)];\n"
-                      "int t06 [1 - 2*(((long) (sizeof (TYPE))) == 6)];\n"
-                      "int t07 [1 - 2*(((long) (sizeof (TYPE))) == 7)];\n"
-                      "int t08 [1 - 2*(((long) (sizeof (TYPE))) == 8)];\n"
-                      "int t09 [1 - 2*(((long) (sizeof (TYPE))) == 9)];\n"
-                      "int t10 [1 - 2*(((long) (sizeof (TYPE))) == 10)];\n"
-                      "int t11 [1 - 2*(((long) (sizeof (TYPE))) == 11)];\n"
-                      "int t12 [1 - 2*(((long) (sizeof (TYPE))) == 12)];\n"
-                      "int t13 [1 - 2*(((long) (sizeof (TYPE))) == 13)];\n"
-                      "int t14 [1 - 2*(((long) (sizeof (TYPE))) == 14)];\n"
-                      "int t15 [1 - 2*(((long) (sizeof (TYPE))) == 15)];\n"
-                      "int t16 [1 - 2*(((long) (sizeof (TYPE))) == 16)];\n"
-                    >>),
-    Res = os:cmd(Compiler ++ " -DTYPE=\""++Type++"\" " ++ TempFile),
-    file:delete(TempFile),
-    case string:tokens(Res, ":") of
-        [_,Ln | _] ->
-            try list_to_integer(Ln) of
-                NumBytes -> integer_to_list(NumBytes*8)
-            catch
-                error:_ ->
-                    ""
-            end;
-        _ ->
-            ""
-    end.
-
-mktemp(Suffix) ->
-    {A,B,C} = erlang:now(),
-    Dir = case os:type() of
-              {windows,_} -> "C:/WINDOWS/TEMP";
-              _ -> "/tmp"
-          end,
-    File = "rebar_"++os:getpid()++
-        integer_to_list(A)++"_"++
-        integer_to_list(B)++"_"++
-        integer_to_list(C)++Suffix,
-    filename:join(Dir,File).
-
-native_wordsize() ->
-    try erlang:system_info({wordsize, external}) of
-        Val ->
-            integer_to_list(8 * Val)
-    catch
-        error:badarg ->
-            integer_to_list(8 * erlang:system_info(wordsize))
-    end.
 
 sh_send(Command0, String, Options0) ->
     ?INFO("sh_send info:\n\tcwd: ~p\n\tcmd: ~s < ~s\n",
@@ -793,4 +677,147 @@ cleanup_code_path(OrigPath) ->
             true;
         _ ->
             code:set_path(OrigPath)
+    end.
+
+wordsize(Arch) when Arch =:= false; Arch =:= "" ->
+    native_wordsize();
+wordsize(Arch) ->
+    AllArchs = [
+                {"i686","32"},
+                {"i386","32"},
+                {"arm","32"},
+                {"aarch64", "64"},
+                {"x86_64","64"}
+               ],
+    case match_wordsize(Arch, AllArchs) of
+        false ->
+            case cross_wordsize(Arch) of
+                "" ->
+                    env_wordsize(os:getenv("REBAR_TARGET_ARCH_WORDSIZE"));
+                WordSize ->
+                    WordSize
+            end;
+        {_, Wordsize} ->
+            Wordsize
+    end.
+
+match_wordsize(Arch, [V={Match,_Bits}|Vs]) ->
+    case re:run(Arch, Match, [{capture, none}]) of
+        match ->
+            V;
+        nomatch ->
+            match_wordsize(Arch, Vs)
+    end;
+match_wordsize(_Arch, []) ->
+    false.
+
+env_wordsize(Wordsize) when Wordsize =:= false;
+                            Wordsize =:= "" ->
+    ?WARN("REBAR_TARGET_ARCH_WORDSIZE not set, assuming 32\n", []),
+    "32";
+env_wordsize(Wordsize) ->
+    case Wordsize of
+        "16" -> Wordsize;
+        "32" -> Wordsize;
+        "64" -> Wordsize;
+        _ ->
+            ?WARN("REBAR_TARGET_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
+            "32"
+    end.
+
+%%
+%% Find out the word size of the target by using Arch-gcc
+%%
+cross_wordsize(Arch) ->
+    cross_sizeof(Arch, "void*").
+
+%%
+%% Find the size of target Type using a specially crafted C file
+%% that will report an error on the line of the byte size of the type.
+%%
+cross_sizeof(Arch, Type) ->
+    Compiler = if Arch =:= "" -> "cc";
+                  true -> Arch ++ "-gcc"
+               end,
+    TempFile = mktempfile(".c"),
+    ok = file:write_file(TempFile,
+                         <<"int t01 [1 - 2*(((long) (sizeof (TYPE))) == 1)];\n"
+                           "int t02 [1 - 2*(((long) (sizeof (TYPE))) == 2)];\n"
+                           "int t03 [1 - 2*(((long) (sizeof (TYPE))) == 3)];\n"
+                           "int t04 [1 - 2*(((long) (sizeof (TYPE))) == 4)];\n"
+                           "int t05 [1 - 2*(((long) (sizeof (TYPE))) == 5)];\n"
+                           "int t06 [1 - 2*(((long) (sizeof (TYPE))) == 6)];\n"
+                           "int t07 [1 - 2*(((long) (sizeof (TYPE))) == 7)];\n"
+                           "int t08 [1 - 2*(((long) (sizeof (TYPE))) == 8)];\n"
+                           "int t09 [1 - 2*(((long) (sizeof (TYPE))) == 9)];\n"
+                           "int t10 [1 - 2*(((long) (sizeof (TYPE))) == 10)];\n"
+                           "int t11 [1 - 2*(((long) (sizeof (TYPE))) == 11)];\n"
+                           "int t12 [1 - 2*(((long) (sizeof (TYPE))) == 12)];\n"
+                           "int t13 [1 - 2*(((long) (sizeof (TYPE))) == 13)];\n"
+                           "int t14 [1 - 2*(((long) (sizeof (TYPE))) == 14)];\n"
+                           "int t15 [1 - 2*(((long) (sizeof (TYPE))) == 15)];\n"
+                           "int t16 [1 - 2*(((long) (sizeof (TYPE))) == 16)];\n"
+                         >>),
+    Cmd = Compiler ++ " -DTYPE=\""++Type++"\" " ++ TempFile,
+    ShOpts = [{use_stdout, false}, return_on_error],
+    {ok, Res} = sh(Cmd, ShOpts),
+    ok = file:delete(TempFile),
+    case string:tokens(Res, ":") of
+        [_, Ln | _] ->
+            try list_to_integer(Ln) of
+                NumBytes -> integer_to_list(NumBytes*8)
+            catch
+                error:_ ->
+                    ""
+            end;
+        _ ->
+            ""
+    end.
+
+mktempfile(Suffix) ->
+    {A,B,C} = rebar_now(),
+    Dir = temp_dir(),
+    File = "rebar_"++os:getpid()++
+        integer_to_list(A)++"_"++
+        integer_to_list(B)++"_"++
+        integer_to_list(C)++Suffix,
+    filename:join(Dir, File).
+
+temp_dir() ->
+    case os:type() of
+        {win32, _} -> windows_temp_dir();
+        _ -> "/tmp"
+    end.
+
+windows_temp_dir() ->
+    case os:getenv("TEMP") of
+        false ->
+            case os:getenv("TMP") of
+                false -> "C:/WINDOWS/TEMP";
+                TMP -> TMP
+            end;
+        TEMP -> TEMP
+    end.
+
+rebar_now() ->
+    case erlang:function_exported(erlang, timestamp, 0) of
+        true ->
+            erlang:timestamp();
+        false ->
+            %% erlang:now/0 was deprecated in 18.0, and as the escript has to
+            %% pass erl_lint:module/1 (even without -mode(compile)), we would
+            %% see a deprecation warning for erlang:now/0.  One solution is to
+            %% use -compile({nowarn_deprecated_function, [{erlang, now, 0}]}),
+            %% but that would raise a warning in versions older than 18.0.
+            %% Calling erlang:now/0 via apply/3 avoids that.
+            apply(erlang, now, [])
+    end.
+
+native_wordsize() ->
+    try erlang:system_info({wordsize, external}) of
+        Val ->
+            integer_to_list(8 * Val)
+    catch
+        error:badarg ->
+            integer_to_list(8 * erlang:system_info(wordsize))
     end.

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -91,13 +91,63 @@ is_arch(ArchRegex) ->
         nomatch ->
             false
     end.
-
+%%
+%% REBAR_ARCH_TARGET, if used, should be set to the "standard" 
+%% target string. That is a prefix for binutils tools.
+%% "x86_64-linux-gnu" or "arm-linux-gnueabi" are good candiates
+%% ${REBAR_ARCH_TARGET}-gcc, ${REBAR_ARCH_TARGET}-ld ...
+%%
 get_arch() ->
-    Words = wordsize(),
-    otp_release() ++ "-"
-        ++ erlang:system_info(system_architecture) ++ "-" ++ Words.
+    Arch = os:getenv("REBAR_ARCH_TARGET"),
+    Words = wordsize(Arch),
+    otp_release() ++ "-" ++ get_system_arch(Arch) ++ "-" ++ Words.
+
+get_system_arch(Arch) when Arch =:= false; Arch =:= "" ->
+    erlang:system_info(system_architecture);
+get_system_arch(Arch) ->
+    Arch.
 
 wordsize() ->
+    wordsize(os:getenv("REBAR_ARCH_TARGET")).
+
+wordsize(Arch) when Arch =:= false; Arch =:= "" ->
+    native_wordsize();
+wordsize(Arch) ->
+    %% add a simple call to gcc to find out?
+    case match_wordsize(Arch, [{"i686","32"}, {"i386","32"},
+                               {"arm","32"}, {"x86_64","64"}]) of
+        false ->
+            env_wordsize(os:getenv("REBAR_ARCH_WORDSIZE"));
+        {_, Wordsize} ->
+            Wordsize
+    end.
+
+match_wordsize(Arch, [V={Match,_Bits}|Vs]) ->
+    case re:run(Arch, Match, [{capture, none}]) of
+        match -> V;
+        _ ->
+            match_wordsize(Arch, Vs)
+    end.
+
+env_wordsize(Wordsize) when Wordsize =:= false;
+                            Wordsize =:= "" ->
+    io:format("REBAR_ARCH_WORDSIZE not set, assuming 32\n"),
+    "32";
+env_wordsize(Wordsize) ->
+    try list_to_integer(Wordsize) of
+        16 -> "16";
+        32 -> "32";
+        64 -> "64";
+        _ ->
+            io:format("REBAR_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
+            "32"
+    catch
+        error:_ ->
+            io:format("REBAR_ARCH_WORDSIZE bad value: ~p\n", [Wordsize]),
+            "32"
+    end.
+
+native_wordsize() ->
     try erlang:system_info({wordsize, external}) of
         Val ->
             integer_to_list(8 * Val)


### PR DESCRIPTION
This is a fixed version of #451:

 * fix commit messages
 * fix whitespace issues
 * move internal helper functions to correct location
 * unexport internal cross arch helper functions
 * fix 18.0 time API compatibility
 * fix Windows temp dir detection
 * use correct helper function name
 * use sh/2 instead of os:cmd/1
 * match file:delete/1 result
 * use logging macros
 * fix typo
 * fix Dialyzer warnings
 * add Tony Rogvall to THANKS
 * add missing termination clause
 * os type must be win32, not windows
 * match file:write_file/2 result
 * document cross-arch variables
 * simplify env_wordsize/1 (Thanks Fred Hebert)