### PR TITLE
Automatically clean neotoma-generated erl files

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -144,3 +144,4 @@ Stavros Aronis
 James Fish
 Tony Rogvall
 Andrey Teplyashin
+John Daily


### PR DESCRIPTION
Remove `.erl` files on clean that appear to have been converted from `.peg`.