### PR TITLE
Allow behaviors defined inside xref_extra_path

### DIFF
--- a/inttest/xref_behavior/gen_xref_behavior.erl
+++ b/inttest/xref_behavior/gen_xref_behavior.erl
@@ -1,0 +1,9 @@
+-module(gen_xref_behavior).
+
+-export([behaviour_info/1]). -ignore_xref([{behaviour_info, 1}]).
+
+behaviour_info(callbacks) ->
+    [{init,1}, {handle, 1}];
+behaviour_info(_Other) ->
+    undefined.
+

--- a/inttest/xref_behavior/rebar.config
+++ b/inttest/xref_behavior/rebar.config
@@ -1,0 +1,6 @@
+{xref_warnings, true}.
+
+{xref_checks, [undefined_function_calls, undefined_functions,
+               locals_not_used, exports_not_used,
+               deprecated_function_calls, deprecated_functions]}.
+

--- a/inttest/xref_behavior/xref_behavior.erl
+++ b/inttest/xref_behavior/xref_behavior.erl
@@ -1,0 +1,10 @@
+-module(xref_behavior).
+-behavior(gen_xref_behavior).
+
+% behavior-defined callbacks don't require xref_ignore
+-export([init/1, handle/1]).
+
+init(_Args) -> ok.
+
+handle(_Atom) -> next_event.
+

--- a/inttest/xref_behavior/xref_behavior_rt.erl
+++ b/inttest/xref_behavior/xref_behavior_rt.erl
@@ -1,0 +1,32 @@
+-module(xref_behavior_rt).
+
+-export([files/0, run/1]).
+
+files() ->
+    [
+     {copy, "../../rebar", "rebar"},
+     {copy, "rebar.config", "rebar.config"},
+     {copy, "xref_behavior.erl", "src/xref_behavior.erl"},
+     {copy, "gen_xref_behavior.erl", "src/gen_xref_behavior.erl"},
+     {create, "ebin/xref_behavior.app", app(xref_behavior,
+                                            [xref_behavior,
+                                             gen_xref_behavior])}
+    ].
+
+run(_Dir) ->
+    {ok, _} = retest_sh:run("./rebar compile", []),
+    {ok, _} = retest_sh:run("./rebar xref", []),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).
+

--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -59,6 +59,11 @@ xref(Config, _) ->
     OrigPath = code:get_path(),
     true = code:add_path(rebar_utils:ebin_dir()),
 
+    %% Add extra paths to code path to, for example, be used
+    %%   when behaviour modules are defined
+    [code:add_path(Path)
+     || Path <- rebar_config:get(Config, xref_extra_paths, [])],
+
     %% Get list of xref checks we want to run
     ConfXrefChecks = rebar_config:get(Config, xref_checks,
                                       [exports_not_used,


### PR DESCRIPTION
Use case: xref'ing a module that defined behavior ranch_protocol was
exiting with
{'EXIT',{undef,[{ranch_protocol,behaviour_info, [callbacks],[]}
