### PR TITLE
Added report and verbose options for LFE compile.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -144,3 +144,4 @@ Stavros Aronis
 James Fish
 Tony Rogvall
 Andrey Teplyashin
+Duncan McGreggor

--- a/src/rebar_lfe_compiler.erl
+++ b/src/rebar_lfe_compiler.erl
@@ -71,7 +71,9 @@ compile_lfe(Source, _Target, Config) ->
             ?FAIL;
         _ ->
             ErlOpts = rebar_utils:erl_opts(Config),
-            Opts = [{i, "include"}, {outdir, "ebin"}, return] ++ ErlOpts,
+            LfeOpts = [report, verbose, {i, "include"}, {outdir, "ebin"},
+                       return],
+            Opts = LfeOpts ++ ErlOpts,
             case lfe_comp:file(Source, Opts) of
                 {ok, _Mod, Ws} ->
                     rebar_base_compiler:ok_tuple(Config, Source, Ws);


### PR DESCRIPTION
Recent builds of LFE have stopped reporting compile errors when compiled with ``rebar``. Examination of this issue revealed that this was due to recent changes in default LFE compile options.

The way that LFE handles compile options has slightly changed; ``verbose`` and ``report`` are now provided as defaults only if no other options are passed; if other options are passed, these do not get set. As a result, we have stopped seeing compile error info when building with ``rebar``.

This change brings back the previous level of reporting that LFE developers had when compiling their projects with ``rebar``.