### PR TITLE
Fix windows eunit tests

### DIFF
--- a/test/rebar_compiler_tests.erl
+++ b/test/rebar_compiler_tests.erl
@@ -84,11 +84,11 @@ not_keep_going_test_() ->
      setup,
      fun() ->
              setup_basic_project(),
-             setup_rebar_config(),
-             rebar("compile")
+             setup_rebar_config()
      end,
      fun teardown/1,
-     fun(RebarOut)->
+     fun()->
+             RebarOut = rebar("compile"),
              [
               {"Exit after error",
                ?_assert(string:str(RebarOut, "ERROR: compile failed") =/= 0)}

--- a/test/rebar_eunit_tests.erl
+++ b/test/rebar_eunit_tests.erl
@@ -56,7 +56,7 @@ eunit_test_() ->
                ?_assert(string:str(RebarOut, "myapp_mymod:") =/= 0)},
 
               {"Tests are only run once",
-               ?_assert(string:str(RebarOut, "All 2 tests passed") =/= 0)}]
+               ?_assert(string:str(RebarOut, "2 tests passed") =/= 0)}]
      end}.
 
 eunit_with_suites_and_tests_test_() ->
@@ -80,7 +80,7 @@ eunit_with_suites_and_tests_test_() ->
                 ?_assert(string:str(RebarOut, "myapp_mymod:") =:= 0)},
 
                {"Selected suite tests are only run once",
-                ?_assert(string:str(RebarOut, "All 4 tests passed") =/= 0)}]
+                ?_assert(string:str(RebarOut, "4 tests passed") =/= 0)}]
       end},
      {"Ensure EUnit runs selected _tests suites",
       setup, fun() ->
@@ -102,7 +102,7 @@ eunit_with_suites_and_tests_test_() ->
                 ?_assert(string:str(RebarOut, "myapp_mymod:") =:= 0)},
 
                {"Selected suite tests are only run once",
-                ?_assert(string:str(RebarOut, "All 2 tests passed") =/= 0)}]
+                ?_assert(string:str(RebarOut, "2 tests passed") =/= 0)}]
       end},
      {"Ensure EUnit runs a specific test defined in a selected suite",
       setup, fun() ->
@@ -154,7 +154,7 @@ eunit_with_suites_and_tests_test_() ->
                                "myapp_mymod2_tests:myfunc2_test/0") =/= 0)]},
 
                {"Selected suite tests are run once",
-                ?_assert(string:str(RebarOut, "All 3 tests passed") =/= 0)}]
+                ?_assert(string:str(RebarOut, "3 tests passed") =/= 0)}]
       end},
      {"Ensure EUnit runs specific test in a _tests suite",
       setup,
@@ -190,7 +190,7 @@ eunit_with_suites_and_tests_test_() ->
                           =/= 0)]},
 
                {"Selected suite tests is run once",
-                ?_assert(string:str(RebarOut, "All 2 tests passed") =/= 0)}]
+                ?_assert(string:str(RebarOut, "2 tests passed") =/= 0)}]
       end},
      {"Ensure EUnit runs a specific test by qualified function name",
       setup,
@@ -325,7 +325,11 @@ environment_test_() ->
 
 assert_rebar_runs() ->
     prepare_rebar_script(),
-    ?assert(string:str(os:cmd(filename:nativename("./" ++ ?TMP_DIR ++ "rebar")),
+    {ok, Cwd} = file:get_cwd(),
+    ok = file:set_cwd(?TMP_DIR),
+    RebarOut = os:cmd(filename:nativename("./rebar")),
+    ok = file:set_cwd(Cwd),
+    ?assert(string:str(RebarOut,
                        "No command to run specified!") =/= 0).
 
 basic_setup_test_() ->

--- a/test/rebar_file_utils_tests.erl
+++ b/test/rebar_file_utils_tests.erl
@@ -36,7 +36,7 @@
 
 -define(TMP_DIR, "tmp_file_utils").
 
--define(SRC, "source dir?").
+-define(SRC, "source dir").
 -define(DST, "dest (dir)").
 -define(FILE1, "file 1").
 -define(FILE2, "file(2)").

--- a/test/rebar_xref_eunit.erl
+++ b/test/rebar_xref_eunit.erl
@@ -192,8 +192,8 @@ prepare_rebar_script() ->
         {unix, _} ->
             [] = os:cmd("chmod u+x " ++ Rebar);
         {win32, _} ->
-            {ok, _} = file:copy(?REBAR_SCRIPT ++ ".bat",
-                                ?TMP_DIR ++ "rebar.bat")
+            {ok, _} = file:copy(?REBAR_SCRIPT ++ ".cmd",
+                                ?TMP_DIR ++ "rebar.cmd")
     end.
 
 rebar() ->


### PR DESCRIPTION
File tests: windows file operations should abort on error
the same as unix operations invoked through sh. Also
windows does not support '?' characters in filenames.

Eunit tests: the 'All' prefix is missing on the 'x tests passed'
message. Eunit only prints the 'All' prefix if there are more
than 2 passed tests, dropping the prefix on the match works
for all cases.