### PR TITLE
Add qualified name tests docs (see pr #119)

### DIFF
--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -128,6 +128,7 @@ info_help(Description) ->
        "               name starts with bar and, if no such test exists,~n"
        "               run the test whose name starts with bar in the~n"
        "               suite's _tests module)~n"
+       "  test[s]=\"foo:bar_test\" (Run bar_test located in module foo)~n"
        "  random_suite_order=true (Run tests in random order)~n"
        "  random_suite_order=Seed (Run tests in random order,~n"
        "                           with the PRNG seeded with Seed)~n"


### PR DESCRIPTION
Documentation for ```eunit tests=mod:foo``` syntax. See comments to #119 for details.