### PR TITLE
Fix paths for libraries and headers from OTP 18.1 and add OTP 18.1 to the list of test environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ otp_release:
   - R14B04
   - R14B03
   - 17.0
+  - 18.1
 before_script:
   - hostname -f
   - cc -v


### PR DESCRIPTION
OTP 18.1 has different paths for erts headers and erl_interface libraries. This pull request not only adds paths for files in new locations but also keeps old paths to provide support for older versions of OTP.

In second commit I add otp 18.1 to the list of test environments.
