### PR TITLE
Lock retest dependency

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
-ExtraDeps = [{retest, ".*", {git, "git://github.com/dizzyd/retest.git"}}],
+ExtraDeps = [{retest, ".*", {git, "git://github.com/dizzyd/retest.git", {tag, "4590941a"}}}],
 
 case os:getenv("REBAR_EXTRA_DEPS") of
     false ->


### PR DESCRIPTION
Retest master right now is broken (my fault actually, bad rebase got merged to master while working on Windows CI), prevents rebar integration tests from succeeding.
