### PR TITLE
Fix FQDN hostname check for unix

### DIFF
--- a/priv/templates/simplenode.runner
+++ b/priv/templates/simplenode.runner
@@ -103,7 +103,7 @@ REMSH_NAME=`echo $NAME_ARG | awk '{print $2}'`
 
 # Test if REMSH_NAME contains a @ and set REMSH_HOSTNAME_PART 
 # and REMSH_NAME_PART according REMSH_TYPE
-MAYBE_FQDN_HOSTNAME=`hostname`
+MAYBE_FQDN_HOSTNAME=`hostname -f`
 HOSTNAME=`echo $MAYBE_FQDN_HOSTNAME | awk -F. '{print $1}'`
 
 REMSH_HOSTNAME_PART="$MAYBE_FQDN_HOSTNAME"


### PR DESCRIPTION
I have generated a release using "rebar generate" and deploy it to a AWS EC2 instance. 
After running "/srv/erlapp/erlapp start" the following error appear: 

"Hostname must be a fqdn domain name when node is configured with long names
and the full node name isn't configured in vm.args"

Running the 'hostname' command i get: ip-10-2x-xxx-x and running 'hostname -f' is 10-2x-xxx-x.us-west-2.compute.internal 

After update the 'erlapp' script to use 'hostname -f' the node started correctly.
