### PR TITLE
Look for ct .spec files in the ct_dir that was specified

### DIFF
--- a/inttest/ct4/ct4_rt.erl
+++ b/inttest/ct4/ct4_rt.erl
@@ -1,0 +1,44 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+-module(ct4_rt).
+
+-compile(export_all).
+
+setup([Target]) ->
+  retest_utils:load_module(filename:join(Target, "inttest_utils.erl")),
+  ok.
+
+files() ->
+    [
+     {create, "ebin/foo.app", app(foo)},
+     {copy, "rebar.config", "rebar.config"},
+     {copy, "foo.test.spec", "test/foo.test.spec"},
+     {copy, "deps/bar.test.spec", "deps/bar.test.spec"},
+     {copy, "deps/bar.test.spec", "baz.test.spec"},
+     {copy, "foo_SUITE.erl", "test/foo_SUITE.erl"}
+    ] ++ inttest_utils:rebar_setup().
+
+run(_Dir) ->
+    Ref = retest:sh("./rebar compile ct -vvv", [async]),
+    {ok, [[CTRunCmd]]} = retest:sh_expect(Ref, "^\"ct_run.*",
+                                  [global, {capture, first, binary}]),
+    {match, _} = re:run(CTRunCmd, "foo.test.spec", [global]),
+    %% deps/bar.test.spec should be ignored by rebar_ct:collect_glob/3
+    nomatch = re:run(CTRunCmd, "bar.test.spec", [global]),
+    %% baz.test.spec should be also ignored by rebar_ct:collect_glob/3
+    %% since we specified in rebar.config that we want to search for
+    %% ct specs from the test dir
+    nomatch = re:run(CTRunCmd, "baz.test.spec", [global]),
+    ok.
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, []},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/ct4/deps/bar.test.spec
+++ b/inttest/ct4/deps/bar.test.spec
@@ -1,0 +1,1 @@
+%% this test spec should be ignored

--- a/inttest/ct4/foo.test.spec
+++ b/inttest/ct4/foo.test.spec
@@ -1,0 +1,1 @@
+{suites, "../", [foo_SUITE]}.

--- a/inttest/ct4/foo_SUITE.erl
+++ b/inttest/ct4/foo_SUITE.erl
@@ -1,0 +1,11 @@
+-module(foo_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+all() -> [simple].
+
+simple(Config) ->
+    io:format("Test: ~p\n", [Config]),
+    ok.

--- a/inttest/ct4/rebar.config
+++ b/inttest/ct4/rebar.config
@@ -1,0 +1,2 @@
+{ct_dir, "test"}.
+{ct_search_specs_from_test_dir, true}.

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -148,6 +148,10 @@
 %% Option to use short names (i.e., -sname test) when starting ct
 {ct_use_short_names, true}.
 
+%% Recursively search for .spec files from the test dir, default
+%% is false (ie. the search will be from the current working directory)
+{ct_search_specs_from_test_dir, true}.
+
 %% == QuickCheck ==
 
 %% If qc_mod is unspecified, rebar tries to detect Triq or EQC


### PR DESCRIPTION
Change existing behaviour which is to find all .spec
files recursively in the current working directory.
This is confusing since the user explicitly stated the
location for his spec files and negates the possibility
to have different spec'ed suites for different environment.

This is a potentially breaking change, projects that have several .spec files across different dirs could be counting on this behaviour, they would have to group them under a single dir.
However this change allows projects to define (using the rebar.config.script facility) separate .spec files with different test suites, so for example under Travis you could run a lighter set of tests and your machine run the full test battery, currently you have no way to accomplish this (with test .spec that is)