### PR TITLE
Treat port env vars as expandable only if they self reference

### DIFF
--- a/inttest/port2/c_src/test1.c
+++ b/inttest/port2/c_src/test1.c
@@ -1,0 +1,13 @@
+#include "test1.h"
+
+#ifndef TEST1
+#error TEST1 is not defined!
+#endif
+
+#ifndef TEST2
+#error TEST2 is not defined!
+#endif
+
+#ifndef TEST3
+#error TEST3 is not defined!
+#endif

--- a/inttest/port2/port2_rt.erl
+++ b/inttest/port2/port2_rt.erl
@@ -1,0 +1,75 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+%% -------------------------------------------------------------------
+%%
+%% rebar: Erlang Build Tools
+%%
+%% Copyright (c) 2016 Luis Rascao
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% -------------------------------------------------------------------
+
+-module(port2_rt).
+-export([files/0,
+         run/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+setup([Target]) ->
+  retest_utils:load_module(filename:join(Target, "inttest_utils.erl")),
+  ok.
+
+files() ->
+    [
+     {copy, "rebar.config", "rebar.config"},
+     {copy, "c_src", "c_src"},
+     {create, "ebin/foo.app", app(foo, [])}
+    ] ++ inttest_utils:rebar_setup().
+
+run(_Dir) ->
+    %% wait a bit for new files to have different timestamps
+    wait(),
+    %% test.so is created during first compile
+    ?assertEqual(0, filelib:last_modified("priv/test.so")),
+    ?assertMatch({ok, _}, retest_sh:run("./rebar compile",
+                                        [{env, [{"ERL_CFLAGS", "-DTEST3=test3"}]}])),
+    TestSo1 = filelib:last_modified("priv/test" ++
+                                    shared_library_file_extension(os:type())),
+    ?assert(TestSo1 > 0).
+
+wait() ->
+    timer:sleep(1000).
+
+object_file_extension({win32, nt}) -> ".o";
+object_file_extension(_) -> ".o".
+
+shared_library_file_extension({win32, nt}) -> ".dll";
+shared_library_file_extension(_) -> ".so".
+
+%%
+%% Generate the contents of a simple .app file
+%%
+app(Name, Modules) ->
+    App = {application, Name,
+           [{description, atom_to_list(Name)},
+            {vsn, "1"},
+            {modules, Modules},
+            {registered, []},
+            {applications, [kernel, stdlib]}]},
+    io_lib:format("~p.\n", [App]).

--- a/inttest/port2/rebar.config
+++ b/inttest/port2/rebar.config
@@ -1,0 +1,9 @@
+{port_specs, [
+    {"(darwin|linux|freebsd)", "priv/test.so",
+         ["c_src/*.c"], [
+            {env, [
+                {"CFLAGS", "$CFLAGS -DTEST1=test1"},
+                {"ERL_CFLAGS", "$ERL_CFLAGS -DTEST2=test2"}
+            ]}
+         ]}
+]}.

--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -495,9 +495,10 @@ expand_command(TmplName, Env, InFiles, OutFile) ->
 
 %%
 %% Given a string, determine if it is expandable
-%%
+%% A string is defined as expandable if it contains itself
+%%  (eg. CFLAGS = -m64 $CFLAGS)
 is_expandable(InStr) ->
-    case re:run(InStr,"\\\$",[{capture,none}]) of
+    case re:run(InStr,"\\\$"++InStr,[{capture,none}]) of
         match -> true;
         nomatch -> false
     end.
@@ -625,6 +626,11 @@ default_env() ->
      {"darwin9.*-64$", "CFLAGS", "-m64 $CFLAGS"},
      {"darwin9.*-64$", "CXXFLAGS", "-m64 $CXXFLAGS"},
      {"darwin9.*-64$", "LDFLAGS", "-arch x86_64 $LDFLAGS"},
+
+     %% OS X Lion onwards flags for 64-bit
+     {"darwin1[0-4].*-64$", "CFLAGS", "-m64 $CFLAGS"},
+     {"darwin1[0-4].*-64$", "CXXFLAGS", "-m64 $CXXFLAGS"},
+     {"darwin1[0-4].*-64$", "LDFLAGS", "-arch x86_64 $LDFLAGS"},
 
      %% OS X Snow Leopard, Lion, and Mountain Lion flags for 32-bit
      {"darwin1[0-2].*-32", "CFLAGS", "-m32 $CFLAGS"},


### PR DESCRIPTION
Addresses #348 
Provide additional port test case.
Also, update newest OS X versions build flags.