### PR TITLE
No such function erlang:timestamp/0

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -800,9 +800,9 @@ windows_temp_dir() ->
     end.
 
 rebar_now() ->
-    case erlang:function_exported(erlang, timestamp, 0) of
+    case erlang:function_exported(os, timestamp, 0) of
         true ->
-            erlang:timestamp();
+            os:timestamp();
         false ->
             %% erlang:now/0 was deprecated in 18.0. One solution to avoid the
             %% deprecation warning is to use


### PR DESCRIPTION
Hello All!
This looks like a typo for me - I can't find erlang:timestamp/0 anywhere, but I clearly see os:timestamp/0 available. So let's fix this.