### PR TITLE
Fix bug when running gcc in cross_sizeof

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -760,7 +760,7 @@ cross_sizeof(Arch, Type) ->
                          >>),
     Cmd = Compiler ++ " -DTYPE=\""++Type++"\" " ++ TempFile,
     ShOpts = [{use_stdout, false}, return_on_error],
-    {ok, Res} = sh(Cmd, ShOpts),
+    {error, {_,Res}} = sh(Cmd, ShOpts),
     ok = file:delete(TempFile),
     case string:tokens(Res, ":") of
         [_, Ln | _] ->


### PR DESCRIPTION
The test program used to determine the word size of a crosscompiler is
crafted to return an error, so this changes the logic to expect an
error exit. If the crosscompiler actually compiles the test program
successfully, that would be remarkable and worthy of investigation.

To test, download the i586 crosscompiler from:
(If on OSX) https://github.com/nerves-project/nerves-toolchain/releases/download/v0.6.0/nerves-i586-unknown-linux-gnu-darwin-x86_64-v0.6.0.tar.xz
(If on Linux) https://github.com/nerves-project/nerves-toolchain/releases/download/v0.6.0/nerves-i586-unknown-linux-gnu-linux-x86_64-v0.6.0.tar.xz

Untar the toolchain and put the `bin` directory in your `PATH`.

`export REBAR_TARGET_ARCH=i586-unknown-linux-gnu`

Run `rebar compile` on any project.
