### PR TITLE
Revert 'Treat port env vars as expandable only if they self reference'

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -495,10 +495,9 @@ expand_command(TmplName, Env, InFiles, OutFile) ->
 
 %%
 %% Given a string, determine if it is expandable
-%% A string is defined as expandable if it contains itself
-%%  (eg. CFLAGS = -m64 $CFLAGS)
+%%
 is_expandable(InStr) ->
-    case re:run(InStr,"\\\$"++InStr,[{capture,none}]) of
+    case re:run(InStr,"\\\$",[{capture,none}]) of
         match -> true;
         nomatch -> false
     end.


### PR DESCRIPTION
Regression introduced in b816c69e343c8fd757c59fe8703eeda597f4da0a.