### PR TITLE
Add an additional check for the existence of a 'rebar.beam' file

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -24,7 +24,10 @@ main(Args) ->
         true ->
             rm("ebin/*.beam");
         false ->
-            rm("ebin/rebar.beam")
+            case filelib:is_file("ebin/rebar.beam") of
+               true -> rm("ebin/rebar.beam");
+               false -> io:fwrite("No beam files found.~n")
+            end
     end,
 
     %% Add check for debug flag


### PR DESCRIPTION
During first bootstrap run, bootstrap fails without any .beam files in the ebin folder.  Relates to issue https://github.com/rebar/rebar/issues/613