### PR TITLE
port_compiler: generate clang compilation db

### DIFF
--- a/inttest/port/port_rt.erl
+++ b/inttest/port/port_rt.erl
@@ -48,6 +48,7 @@ run(_Dir) ->
     %% test.so is created during first compile
     ?assertEqual(0, filelib:last_modified("priv/test.so")),
     ?assertMatch({ok, _}, retest_sh:run("./rebar compile", [])),
+    ?assertMatch(true, filelib:is_regular("compile_commands.json")),
     TestSo1 = filelib:last_modified("priv/test" ++
                                     shared_library_file_extension(os:type())),
     ?assert(TestSo1 > 0),


### PR DESCRIPTION
In order for newer clang tools to work, they require the presence of a
compilation database in the form of compile_commands.json.  Therefore,
we adapt port_compiler to write such a file.