### PR TITLE
Properly skip apps with a .app.src.script file

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -190,8 +190,8 @@ skip_or_process_dir(Dir, Command, Config, DirSet, CurrentCodePath,
                  WouldCd);
 skip_or_process_dir(Dir, Command, Config, DirSet, CurrentCodePath,
                     {_, File}=ModuleSet, WouldCd) ->
-    case lists:suffix(".app.src", File)
-        orelse lists:suffix(".app", File) of
+    case lists:suffix(".app", File)
+        orelse rebar_app_utils:is_app_src(File) of
         true ->
             %% .app or .app.src file, check if is_skipped_app
             skip_or_process_dir1(Dir, Command, Config, DirSet, CurrentCodePath,


### PR DESCRIPTION
Any application using a .app.src.script file will now be properly
skipped if requested. This check was missing the newer third case for
the file extension.