### PR TITLE
Drop crypto app reliance

### DIFF
--- a/ebin/rebar.app
+++ b/ebin/rebar.app
@@ -55,7 +55,6 @@
     stdlib,
     sasl,
     compiler,
-    crypto,
     syntax_tools,
     tools,
     eunit,

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,8 @@
       - (\"diameter_dict_util\":\"parse\"/\"2\")
       - (\"erlang\":\"timestamp\"/\"0\")
       - (\"rebar_rnd\":\"seed\"/\"1\")
-      - (\"rebar_rnd\":\"uniform\"/\"0\"))",
+      - (\"rebar_rnd\":\"uniform\"/\"0\")
+      - (\"rebar_rnd\":\"uniform\"/\"1\"))",
          []}]}.
 
 {dialyzer,

--- a/src/rebar.erl
+++ b/src/rebar.erl
@@ -208,12 +208,6 @@ profile(_Config, _Commands, Profiler) ->
     ?ABORT("Unsupported profiler: ~s~n", [Profiler]).
 
 run_aux(BaseConfig, Commands) ->
-    %% Make sure crypto is running
-    case crypto:start() of
-        ok -> ok;
-        {error,{already_started,crypto}} -> ok
-    end,
-
     %% Make sure memoization server is running
     case rmemo:start() of
         {ok, _} -> ok;

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -237,6 +237,7 @@ make_cmd(TestDir, RawLogDir, Config) ->
     CodeDirs = [io_lib:format("\"~s\"", [Dir]) ||
                    Dir <- [EbinDir|NonLibCodeDirs]],
     CodePathString = string:join(CodeDirs, " "),
+    _ = rebar_rnd:seed({55, seconds(), 7331}),
     Cmd = case get_ct_specs(Config, search_ct_specs_from(Cwd, TestDir, Config)) of
               undefined ->
                   ?FMT("~s"
@@ -285,13 +286,18 @@ search_ct_specs_from(Cwd, TestDir, Config) ->
           Cwd
     end.
 
+seconds() ->
+    calendar:datetime_to_gregorian_seconds(calendar:universal_time()).
+
 build_name(Config) ->
     %% generate a unique name for our test node, we want
     %% to make sure the odds of name clashing are low
-    Random = integer_to_list(rebar_rnd:uniform(10000)),
+    Secs = integer_to_list(seconds()),
+    Random = integer_to_list(rebar_rnd:uniform(1000000)),
+    PseudoUnique = Random ++ "N" ++ Secs,
     case rebar_config:get_local(Config, ct_use_short_names, false) of
-        true -> "-sname test" ++ Random;
-        false -> " -name test" ++ Random ++ "@" ++ net_adm:localhost()
+        true -> "-sname test" ++ PseudoUnique;
+        false -> " -name test" ++ PseudoUnique ++ "@" ++ net_adm:localhost()
     end.
 
 get_extra_params(Config) ->

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -288,7 +288,7 @@ search_ct_specs_from(Cwd, TestDir, Config) ->
 build_name(Config) ->
     %% generate a unique name for our test node, we want
     %% to make sure the odds of name clashing are low
-    Random = integer_to_list(crypto:rand_uniform(0, 10000)),
+    Random = integer_to_list(rebar_rnd:uniform(10000)),
     case rebar_config:get_local(Config, ct_use_short_names, false) of
         true -> "-sname test" ++ Random;
         false -> " -name test" ++ Random ++ "@" ++ net_adm:localhost()

--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -279,7 +279,7 @@ randomize_suites(Config, Modules) ->
         undefined ->
             Modules;
         "true" ->
-            Seed = crypto:rand_uniform(1, 65535),
+            Seed = rebar_rnd:uniform(65535),
             randomize_suites1(Modules, Seed);
         String ->
             try list_to_integer(String) of


### PR DESCRIPTION
By doing this, we fix two issues at once. First, there's no need to have
crypto available anymore. While not having crypto in your Erlang
installation is a questionable packaging decision, it tends to happen in
the wild with users installing Erlang and missing crypto. Sometimes this
is not due to a distro's package but users building Erlang without the
needed OpenSSL dependencies. Second, this resolves the Erlang 20 rng
deprecation warnings.