### PR TITLE
Log out success message with newlines

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -150,3 +150,4 @@ John Daily
 Yury Gargay
 Frank Hunleth
 Matwey Kornilov
+Julius Andrikonis

--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -193,7 +193,7 @@ check_log(Config,RawLogFilename,Fun) ->
             ?FAIL;
 
         true ->
-            Fun(Msg)
+            Fun(string:join(Msg, "\n"))
     end.
 
 


### PR DESCRIPTION
The raw log file is split into lines to check for errors.
However the logged message should contain newlines for easier reading.